### PR TITLE
Dev

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && contains(github.event.head_commit.message, '[deploy]')
     environment:
       name: pypi
       url: https://pypi.org/p/data-formulator


### PR DESCRIPTION
update the workflow so that pypi deploy only runs when "[deploy]" is in the commit message. This will help us with a green build icon when we don't bump the pypi version.