### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Play with Data Formulator with one of the following options:
   # start data_formulator
   data_formulator 
   
-  # alternatively, you can run data formualtor with this command
+  # alternatively, you can run data formulator with this command
   python -m data_formulator
   ```
 


### PR DESCRIPTION
Something that I found while I was reading the `README.md` of the project. There is a minor typo on the code block about Option 1 to install the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R59): Corrected typo in the comment from "formualtor" to "formulator" for the Option 1 code block.