### PR TITLE
Support custom models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 
-
-*openai-keys.env 
+*api-keys.env
 **/*.ipynb_checkpoints/
 
 .DS_Store

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,8 +18,13 @@ How to set up your local machine.
     ```bash
     pip install -r requirements.txt
     ```
+- **Configure environment variable (optional)s**
+    - copy `api-keys.env.example` to `api-keys.env` and add your API keys.
+    - required fields for different providers are different, please refer to the [LiteLLM setup](https://docs.litellm.ai/docs#litellm-python-sdk) guide for more details.
+        - currently only endpoint, model, api_key, api_base, api_version are supported.
+    - this helps data formulator to automatically load the API keys when you run the app, so you don't need to set the API keys in the app UI.
 
-- **Run**
+- **Run the app**
     - **Windows**
     ```bash
     .\local_server.bat
@@ -27,7 +32,7 @@ How to set up your local machine.
 
     - **Unix-based**
     ```bash
-    .\local_server.sh
+    ./local_server.sh
     ```
 
 ## Frontend (TypeScript)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Transform data and create rich visualizations iteratively with AI 🪄. Try Data
 
 ## News 🔥🔥🔥
 
+- [02-12-2025] Run Data Formulator with different models (powered by [LiteLLM](https://github.com/BerriAI/litellm))!
+  - You can now run Data Formulator with different models by specifying the model in the model selection dialog.
+  - We have tested with OpenAI, Azure, Ollama, and Anthropic. Models with good code generation capabilities are recommended (gpt-4o, gpt-4o-mini, claude-3-5-sonnet etc.).
+  - If running locally, you can also save your API keys in the `api-keys.env` file (check `api-keys.env.template` for reference), Data Formulator will automatically load them.
+
 - [11-07-2024] Minor fun update: data visualization challenges!
   - We added a few visualization challenges with the sample datasets. Can you complete them all? [[try them out!]](https://github.com/microsoft/data-formulator/issues/53#issue-2641841252)
   - Comment in the issue when you did, or share your results/questions with others! [[comment here]](https://github.com/microsoft/data-formulator/issues/53)
@@ -77,7 +82,7 @@ Play with Data Formulator with one of the following options:
 
 ## Using Data Formulator
 
-Once you’ve completed the setup using either option, follow these steps to start using Data Formulator:
+Once you've completed the setup using either option, follow these steps to start using Data Formulator:
 
 ### The basics of data visualization
 * Provide OpenAI keys and select a model (GPT-4o suggested) and choose a dataset.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Transform data and create rich visualizations iteratively with AI 🪄. Try Data
 
 ## News 🔥🔥🔥
 
-- [02-12-2025] Run Data Formulator with different models (powered by [LiteLLM](https://github.com/BerriAI/litellm))!
-  - You can now run Data Formulator with different models by specifying the model in the model selection dialog.
-  - We have tested with OpenAI, Azure, Ollama, and Anthropic. Models with good code generation capabilities are recommended (gpt-4o, gpt-4o-mini, claude-3-5-sonnet etc.).
-  - If running locally, you can also save your API keys in the `api-keys.env` file (check `api-keys.env.template` for reference), Data Formulator will automatically load them.
+- [02-12-2025] More models supported now! Powered by [LiteLLM](https://github.com/BerriAI/litellm)!
+  - Now supports OpenAI, Azure, Ollama, and Anthropic models (and more based on LiteLLM);
+  - Models with strong code generation capabilities are recommended (gpt-4o, claude-3-5-sonnet etc.);
+  - You can store API keys in `api-keys.env` to avoid typing them every time (see template `api-keys.env.template`).
+  - Let us know which models you have good/bad experiences with, and what models you would like to see supported! [[comment here]](https://github.com/microsoft/data-formulator/issues/49)
 
 - [11-07-2024] Minor fun update: data visualization challenges!
   - We added a few visualization challenges with the sample datasets. Can you complete them all? [[try them out!]](https://github.com/microsoft/data-formulator/issues/53#issue-2641841252)

--- a/api-keys.env.template
+++ b/api-keys.env.template
@@ -1,0 +1,20 @@
+# OpenAI Configuration
+OPENAI_ENABLED=true
+OPENAI_API_KEY=#your-openai-api-key
+OPENAI_MODELS=gpt-4o,gpt-4o-mini
+
+# Azure OpenAI Configuration
+AZURE_ENABLED=true
+AZURE_API_BASE=https://your-azure-openai-endpoint.openai.azure.com/
+AZURE_API_VERSION=2024-02-15-preview
+AZURE_MODELS=gpt-4o
+
+# Anthropic Configuration
+ANTHROPIC_ENABLED=true
+ANTHROPIC_API_KEY=#your-anthropic-api-key
+ANTHROPIC_MODELS=claude-3-5-sonnet-20241022,claude-3-5-haiku-20241022
+
+# Ollama Configuration
+OLLAMA_ENABLED=true
+OLLAMA_API_BASE=http://localhost:11434
+OLLAMA_MODELS=codellama

--- a/api-keys.env.template
+++ b/api-keys.env.template
@@ -1,10 +1,11 @@
 # OpenAI Configuration
 OPENAI_ENABLED=true
 OPENAI_API_KEY=#your-openai-api-key
-OPENAI_MODELS=gpt-4o,gpt-4o-mini
+OPENAI_MODELS=gpt-4o,gpt-4o-mini # comma separated list of models
 
 # Azure OpenAI Configuration
 AZURE_ENABLED=true
+AZURE_API_KEY=#your-azure-openai-api-key
 AZURE_API_BASE=https://your-azure-openai-endpoint.openai.azure.com/
 AZURE_API_VERSION=2024-02-15-preview
 AZURE_MODELS=gpt-4o
@@ -17,4 +18,7 @@ ANTHROPIC_MODELS=claude-3-5-sonnet-20241022,claude-3-5-haiku-20241022
 # Ollama Configuration
 OLLAMA_ENABLED=true
 OLLAMA_API_BASE=http://localhost:11434
-OLLAMA_MODELS=codellama:7b
+OLLAMA_MODELS=codellama:7b # models with good code generation capabilities recommended
+
+# if you want to add other models, you can add them with PROVIDER_API_KEY=your-api-key, PROVIDER_MODELS=model1,model2 etc 
+# (replacing PROVIDER with the provider name like GEMINI, ANTHROPIC, AZURE, OPENAI, OLLAMA etc. as long as they are supported by LiteLLM)

--- a/api-keys.env.template
+++ b/api-keys.env.template
@@ -17,4 +17,4 @@ ANTHROPIC_MODELS=claude-3-5-sonnet-20241022,claude-3-5-haiku-20241022
 # Ollama Configuration
 OLLAMA_ENABLED=true
 OLLAMA_API_BASE=http://localhost:11434
-OLLAMA_MODELS=codellama
+OLLAMA_MODELS=codellama:7b

--- a/py-src/data_formulator/agents/agent_code_explanation.py
+++ b/py-src/data_formulator/agents/agent_code_explanation.py
@@ -83,7 +83,6 @@ class CodeExplanationAgent(object):
         ###### the part that calls open_ai
         response = self.client.get_completion(messages = messages)
         
-        logger.info('\n=== explanation output ===>\n')
-        logger.info(response.choices[0].message.content)
+        logger.info(f"=== explanation output ===>\n{response.choices[0].message.content}\n")
         
         return response.choices[0].message.content

--- a/py-src/data_formulator/agents/agent_code_explanation.py
+++ b/py-src/data_formulator/agents/agent_code_explanation.py
@@ -66,9 +66,8 @@ def transform_data(df_0):
 
 class CodeExplanationAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def run(self, input_tables, code):
 
@@ -82,9 +81,7 @@ class CodeExplanationAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=1, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
         
         logger.info('\n=== explanation output ===>\n')
         logger.info(response.choices[0].message.content)

--- a/py-src/data_formulator/agents/agent_concept_derive.py
+++ b/py-src/data_formulator/agents/agent_concept_derive.py
@@ -167,9 +167,8 @@ Derive average grade from writing, reading, math, grade should be A, B, C, D, F
 
 class ConceptDeriveAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def run(self, input_table, input_fields, output_field, description, n=1):
         """derive a new concept based on input table, input fields, and output field name, (and description)
@@ -190,9 +189,7 @@ class ConceptDeriveAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
 

--- a/py-src/data_formulator/agents/agent_data_clean.py
+++ b/py-src/data_formulator/agents/agent_data_clean.py
@@ -78,8 +78,7 @@ Totals (7 entries)	5	5	5	15
 
 class DataCleanAgent(object):
 
-    def __init__(self, client, model):
-        self.model = model
+    def __init__(self, client):
         self.client = client
 
     def run(self, content_type, raw_data, image_cleaning_instruction):
@@ -129,9 +128,7 @@ class DataCleanAgent(object):
         messages = [system_message, user_prompt]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=1, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         candidates = []
         for choice in response.choices:

--- a/py-src/data_formulator/agents/agent_data_filter.py
+++ b/py-src/data_formulator/agents/agent_data_filter.py
@@ -125,9 +125,8 @@ def filter_row(row, df):
 
 class DataFilterAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def process_gpt_result(self, input_table, response, messages):
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
@@ -177,9 +176,7 @@ class DataFilterAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=1, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         return self.process_gpt_result(input_table, response, messages)
 
@@ -190,8 +187,6 @@ class DataFilterAgent(object):
                               "content": new_instruction + '\nupdate the filter function accordingly'}]
 
         ##### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages=messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         return self.process_gpt_result(input_table, response, messages)

--- a/py-src/data_formulator/agents/agent_data_load.py
+++ b/py-src/data_formulator/agents/agent_data_load.py
@@ -124,9 +124,8 @@ table_0 (weather_seattle_atlanta) sample:
 
 class DataLoadAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def run(self, input_data, n=1):
 
@@ -140,9 +139,7 @@ class DataLoadAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages=messages, temperature=0.2, max_tokens=4096,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
 

--- a/py-src/data_formulator/agents/agent_data_rec.py
+++ b/py-src/data_formulator/agents/agent_data_rec.py
@@ -126,9 +126,8 @@ def transform_data(df):
 
 class DataRecAgent(object):
 
-    def __init__(self, client, model, system_prompt=None):
+    def __init__(self, client, system_prompt=None):
         self.client = client
-        self.model = model
         self.system_prompt = system_prompt if system_prompt is not None else SYSTEM_PROMPT
 
     def process_gpt_response(self, input_tables, messages, response):
@@ -192,7 +191,7 @@ class DataRecAgent(object):
         messages = [{"role":"system", "content": self.system_prompt},
                     {"role":"user","content": user_query}]
         
-        response = completion_response_wrapper(self.client, self.model, messages, n)
+        response = completion_response_wrapper(self.client, messages, n)
         
         return self.process_gpt_response(input_tables, messages, response)
         
@@ -204,7 +203,6 @@ class DataRecAgent(object):
 
         messages = [*dialog, {"role":"user", "content": f"Update: \n\n{new_instruction}"}]
 
-        ##### the part that calls open_ai
-        response = completion_response_wrapper(self.client, self.model, messages, n)
+        response = completion_response_wrapper(self.client, messages, n)
 
         return self.process_gpt_response(input_tables, messages, response)

--- a/py-src/data_formulator/agents/agent_data_rec.py
+++ b/py-src/data_formulator/agents/agent_data_rec.py
@@ -170,7 +170,7 @@ class DataRecAgent(object):
                     logger.warning(error_message)
                     result = {'status': 'other error', 'code': code_str, 'content': f"Unexpected error: {error_message}"}
             else:
-                result = {'status': 'no transformation', 'code': "", 'content': input_tables[0]['rows']}
+                result = {'status': 'error', 'code': "", 'content': "No code block found in the response. The model is unable to generate code to complete the task."}
             
             result['dialog'] = [*messages, {"role": choice.message.role, "content": choice.message.content}]
             result['agent'] = 'DataRecAgent'

--- a/py-src/data_formulator/agents/agent_data_transform_v2.py
+++ b/py-src/data_formulator/agents/agent_data_transform_v2.py
@@ -207,8 +207,8 @@ class DataTransformationAgentV2(object):
         
         candidates = []
         for choice in response.choices:
-            # logger.info("\n=== Data transformation result ===>\n")
-            # logger.info(choice.message.content + "\n")
+            print("\n=== Data transformation result ===>\n")
+            print(choice.message.content + "\n")
             
             json_blocks = extract_json_objects(choice.message.content + "\n")
             if len(json_blocks) > 0:
@@ -217,6 +217,9 @@ class DataTransformationAgentV2(object):
                 refined_goal = {'visualization_fields': [], 'instruction': '', 'reason': ''}
 
             code_blocks = extract_code_from_gpt_response(choice.message.content + "\n", "python")
+
+            print("\n=== Code blocks ===>\n")
+            print(code_blocks)
 
             if len(code_blocks) > 0:
                 code_str = code_blocks[-1]
@@ -234,14 +237,17 @@ class DataTransformationAgentV2(object):
                     logger.warning('Error occurred during code execution:')
                     error_message = f"An error occurred during code execution. Error type: {type(e).__name__}"
                     logger.warning(error_message)
-                    result = {'status': 'other error', 'code': code_str, 'content': error_message}
+                    result = {'status': 'error', 'code': code_str, 'content': error_message}
             else:
-                result = {'status': 'no transformation', 'code': "", 'content': input_tables[0]['rows']}
+                result = {'status': 'error', 'code': "", 'content': "No code block found in the response. The model is unable to generate code to complete the task."}
             
             result['dialog'] = [*messages, {"role": choice.message.role, "content": choice.message.content}]
             result['agent'] = 'DataTransformationAgent'
             result['refined_goal'] = refined_goal
             candidates.append(result)
+
+        print("\n=== Candidates ===>\n")
+        print(candidates)
 
         return candidates
 

--- a/py-src/data_formulator/agents/agent_data_transform_v2.py
+++ b/py-src/data_formulator/agents/agent_data_transform_v2.py
@@ -178,12 +178,10 @@ def transform_data(df):
 ```
 '''
 
-def completion_response_wrapper(client, model, messages, n):
+def completion_response_wrapper(client, messages, n):
     ### wrapper for completion response, especially handling errors
     try:
-        response = client.chat.completions.create(
-                model=model, messages=messages, temperature=0.7, max_tokens=1200,
-                top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = client.get_completion(messages = messages)
     except Exception as e:
         response = e
 
@@ -192,9 +190,8 @@ def completion_response_wrapper(client, model, messages, n):
 
 class DataTransformationAgentV2(object):
 
-    def __init__(self, client, model, system_prompt=None):
+    def __init__(self, client, system_prompt=None):
         self.client = client
-        self.model = model
         self.system_prompt = system_prompt if system_prompt is not None else SYSTEM_PROMPT
 
     def process_gpt_response(self, input_tables, messages, response):
@@ -265,7 +262,7 @@ class DataTransformationAgentV2(object):
         messages = [{"role":"system", "content": self.system_prompt},
                     {"role":"user","content": user_query}]
         
-        response = completion_response_wrapper(self.client, self.model, messages, n)
+        response = completion_response_wrapper(self.client, messages, n)
 
         return self.process_gpt_response(input_tables, messages, response)
         
@@ -287,6 +284,6 @@ class DataTransformationAgentV2(object):
         messages = [*updated_dialog, {"role":"user", 
                               "content": f"Update the code above based on the following instruction:\n\n{json.dumps(goal, indent=4)}"}]
 
-        response = completion_response_wrapper(self.client, self.model, messages, n)
+        response = completion_response_wrapper(self.client, messages, n)
 
         return self.process_gpt_response(input_tables, messages, response)

--- a/py-src/data_formulator/agents/agent_data_transform_v2.py
+++ b/py-src/data_formulator/agents/agent_data_transform_v2.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import json
+import sys
 
 from data_formulator.agents.agent_utils import extract_json_objects, generate_data_summary, extract_code_from_gpt_response
 import data_formulator.py_sandbox as py_sandbox
@@ -10,6 +11,7 @@ import traceback
 
 import logging
 
+# Replace/update the logger configuration
 logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = '''You are a data scientist to help user to transform data that will be used for visualization.
@@ -207,8 +209,8 @@ class DataTransformationAgentV2(object):
         
         candidates = []
         for choice in response.choices:
-            print("\n=== Data transformation result ===>\n")
-            print(choice.message.content + "\n")
+            logger.info("=== Data transformation result ===>")
+            logger.info(choice.message.content + "\n")
             
             json_blocks = extract_json_objects(choice.message.content + "\n")
             if len(json_blocks) > 0:
@@ -218,8 +220,8 @@ class DataTransformationAgentV2(object):
 
             code_blocks = extract_code_from_gpt_response(choice.message.content + "\n", "python")
 
-            print("\n=== Code blocks ===>\n")
-            print(code_blocks)
+            logger.info("=== Code blocks ===>")
+            logger.info(code_blocks)
 
             if len(code_blocks) > 0:
                 code_str = code_blocks[-1]
@@ -246,8 +248,8 @@ class DataTransformationAgentV2(object):
             result['refined_goal'] = refined_goal
             candidates.append(result)
 
-        print("\n=== Candidates ===>\n")
-        print(candidates)
+        logger.info("=== Candidates ===>")
+        logger.info(candidates)
 
         return candidates
 

--- a/py-src/data_formulator/agents/agent_data_transformation.py
+++ b/py-src/data_formulator/agents/agent_data_transformation.py
@@ -122,9 +122,8 @@ def transform_data(df_0):
 
 class DataTransformationAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def process_gpt_response(self, input_tables, messages, response):
         """process gpt response to handle execution"""
@@ -185,9 +184,7 @@ class DataTransformationAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
         
         return self.process_gpt_response(input_tables, messages, response)
 
@@ -207,9 +204,7 @@ class DataTransformationAgent(object):
                               "content": "Update the code above based on the following instruction:\n\n" + new_instruction + output_fields_instr}]
 
         ##### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages=messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
         
         logger.info(response)
         

--- a/py-src/data_formulator/agents/agent_generic_py_concept.py
+++ b/py-src/data_formulator/agents/agent_generic_py_concept.py
@@ -157,9 +157,8 @@ def derive(row, df):
 
 class GenericPyConceptDeriveAgent(object):
 
-    def __init__(self, client, model_version):
+    def __init__(self, client):
         self.client = client
-        self.model_version = model_version
 
     def process_gpt_response(self, input_table, output_field, response, messages):
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
@@ -220,10 +219,7 @@ output = json.dumps(df.to_dict("records"))
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model_version, 
-            messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=1, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         return self.process_gpt_response(input_table, output_field, response, messages)
 
@@ -234,9 +230,7 @@ output = json.dumps(df.to_dict("records"))
                               "content": new_instruction + '\n update the function accordingly'}]
 
         ##### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages=messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         candidates = self.process_gpt_response(input_table, output_field, response, messages)
 

--- a/py-src/data_formulator/agents/agent_py_concept_derive.py
+++ b/py-src/data_formulator/agents/agent_py_concept_derive.py
@@ -131,8 +131,7 @@ def derive(writing, reading, math):
 
 class PyConceptDeriveAgent(object):
 
-    def __init__(self, client, model):
-        self.model = model
+    def __init__(self, client):
         self.client = client
 
     def run(self, input_table, input_fields, output_field, description):
@@ -163,9 +162,7 @@ def derive({arg_string}):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.7, max_tokens=1200,
-            top_p=0.95, n=1, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
 

--- a/py-src/data_formulator/agents/agent_sort_data.py
+++ b/py-src/data_formulator/agents/agent_sort_data.py
@@ -65,9 +65,8 @@ For example:
 
 class SortDataAgent(object):
 
-    def __init__(self, client, model):
+    def __init__(self, client):
         self.client = client
-        self.model = model
 
     def run(self, name, values, n=1):
 
@@ -84,9 +83,7 @@ class SortDataAgent(object):
                     {"role":"user","content": user_query}]
         
         ###### the part that calls open_ai
-        response = self.client.chat.completions.create(
-            model=self.model, messages = messages, temperature=0.2, max_tokens=2400,
-            top_p=0.95, n=n, frequency_penalty=0, presence_penalty=0, stop=None)
+        response = self.client.get_completion(messages = messages)
 
         #log = {'messages': messages, 'response': response.model_dump(mode='json')}
 

--- a/py-src/data_formulator/agents/agent_utils.py
+++ b/py-src/data_formulator/agents/agent_utils.py
@@ -66,6 +66,7 @@ def table_hash(table):
     frozen_table = tuple(sorted([tuple([hash(value_handling_func(r[key])) for key in schema]) for r in table]))
     return hash(frozen_table)
 
+
 def extract_code_from_gpt_response(code_raw, language):
     """search for matches and then look for pairs of ```...``` to extract code"""
 

--- a/py-src/data_formulator/agents/client_utils.py
+++ b/py-src/data_formulator/agents/client_utils.py
@@ -10,13 +10,8 @@ class Client(object):
     """
     def __init__(self, endpoint, model, api_key=None,  api_base=None, api_version=None):
         
-        if endpoint == "default":
-            self.endpoint = os.getenv("ENDPOINT", "azure_openai")
-            self.model = model
-            api_base = os.getenv("API_BASE")
-        else:
-            self.endpoint = endpoint
-            self.model = model
+        self.endpoint = endpoint
+        self.model = model
 
         # other params, including temperature, max_completion_tokens, api_base, api_version
         self.params = {
@@ -35,7 +30,7 @@ class Client(object):
                 self.model = model
             else:
                 self.model = f"anthropic/{model}"
-        elif self.endpoint == "azure_openai":
+        elif self.endpoint == "azure":
             self.params["api_base"] = api_base
             self.params["api_version"] = api_version if api_version else "2024-02-15-preview"
             if api_key is None or api_key == "":

--- a/py-src/data_formulator/agents/client_utils.py
+++ b/py-src/data_formulator/agents/client_utils.py
@@ -1,35 +1,66 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
-
-import openai
 import os
-import sys
-
+from litellm import completion
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 
-def get_client(endpoint, key):
+class Client(object):
+    """
+    Returns a LiteLLM client configured for the specified endpoint and model.
+    Supports OpenAI, Azure, Ollama, and other providers via LiteLLM.
+    """
+    def __init__(self, endpoint, model, api_key=None,  api_base=None, api_version=None):
+        
+        if endpoint == "default":
+            self.endpoint = os.getenv("ENDPOINT", "azure_openai")
+            self.model = model
+            api_base = os.getenv("API_BASE")
+        else:
+            self.endpoint = endpoint
+            self.model = model
 
-	endpoint = os.getenv("ENDPOINT") if endpoint == "default" else endpoint
+        # other params, including temperature, max_completion_tokens, api_base, api_version
+        self.params = {
+            "api_key": api_key,
+            "temperature": 0.7,
+            "max_completion_tokens": 1200,
+        }
 
-	if key is None or key == "":
-		# using azure keyless access method
-		token_provider = get_bearer_token_provider(
-			DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-		)
-		print(token_provider)
-		print(endpoint)
-		client = openai.AzureOpenAI(
-			api_version="2024-02-15-preview",
-			azure_endpoint=endpoint,
-			azure_ad_token_provider=token_provider
-		)
-	elif endpoint == 'openai':
-		client = openai.OpenAI(api_key=key)
-	else:
-		client = openai.AzureOpenAI(
-			azure_endpoint = endpoint,  
-			api_key=key,  
-			api_version="2024-02-15-preview"
-		)
-	return client
+        if self.endpoint == "gemini":
+            if model.startswith("gemini/"):
+                self.model = model
+            else:
+                self.model = f"gemini/{model}"
+        elif self.endpoint == "anthropic":
+            if model.startswith("anthropic/"):
+                self.model = model
+            else:
+                self.model = f"anthropic/{model}"
+        elif self.endpoint == "azure_openai":
+            self.params["api_base"] = api_base
+            self.params["api_version"] = api_version if api_version else "2024-02-15-preview"
+            if api_key is None or api_key == "":
+                token_provider = get_bearer_token_provider(
+                    DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+                )
+                self.params["azure_ad_token_provider"] = token_provider
+            self.params["custom_llm_provider"] = "azure"
+        elif self.endpoint == "ollama":
+            self.params["api_base"] = api_base if api_base else "http://localhost:11434"
+            self.params["max_tokens"] = self.params["max_completion_tokens"]
+            if model.startswith("ollama/"):
+                self.model = model
+            else:
+                self.model = f"ollama/{model}"
+
+    def get_completion(self, messages):
+        """
+        Returns a LiteLLM client configured for the specified endpoint and model.
+        Supports OpenAI, Azure, Ollama, and other providers via LiteLLM.
+        """
+        # Configure LiteLLM 
+        return completion(
+            model=self.model,
+            messages=messages,
+            drop_params=True,
+            **self.params
+        )

--- a/py-src/data_formulator/app.py
+++ b/py-src/data_formulator/app.py
@@ -20,6 +20,8 @@ import threading
 
 from flask_cors import CORS
 
+import logging
+
 import json
 import time
 from pathlib import Path
@@ -41,16 +43,37 @@ from dotenv import load_dotenv
 
 APP_ROOT = Path(os.path.join(Path(__file__).parent)).absolute()
 
+import os
+
+app = Flask(__name__, static_url_path='', static_folder=os.path.join(APP_ROOT, "dist"))
+CORS(app)
+
 print(APP_ROOT)
 
 # Load the single environment file
 load_dotenv(os.path.join(APP_ROOT, "..", "..", 'api-keys.env'))
 load_dotenv(os.path.join(APP_ROOT, 'api-keys.env'))
 
-import os
+# Configure root logger for general application logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
 
-app = Flask(__name__, static_url_path='', static_folder=os.path.join(APP_ROOT, "dist"))
-CORS(app)
+# Get logger for this module
+logger = logging.getLogger(__name__)
+
+# Configure Flask app logger to use the same settings
+app.logger.handlers = []
+for handler in logging.getLogger().handlers:
+    app.logger.addHandler(handler)
+
+# Example usage:
+logger.info("Application level log")  # General application logging
+app.logger.info("Flask specific log") # Web request related logging
+
+
 
 def get_client(model_config):
     for key in model_config:

--- a/py-src/data_formulator/app.py
+++ b/py-src/data_formulator/app.py
@@ -54,13 +54,13 @@ CORS(app)
 
 def get_client(model_config):
     for key in model_config:
-        model_config[key] = html.escape(model_config[key].strip())
+        model_config[key] = model_config[key].strip()
 
     client = Client(
         model_config["endpoint"],
         model_config["model"],
         model_config["api_key"] if "api_key" in model_config else None,
-        model_config["api_base"] if "api_base" in model_config else None,
+        html.escape(model_config["api_base"]) if "api_base" in model_config else None,
         model_config["api_version"] if "api_version" in model_config else None)
 
     return client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
     "azure-identity",  
     "azure-keyvault-secrets",  
     "python-dotenv",  
-    "vega_datasets"
+    "vega_datasets",
+    "litellm"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ azure-identity
 azure-keyvault-secrets
 python-dotenv
 vega_datasets
+litellm
 -e . #also need to install data formulator itself

--- a/src/app/dfSlice.tsx
+++ b/src/app/dfSlice.tsx
@@ -257,7 +257,7 @@ export const dataFormulatorSlice = createSlice({
             let savedState = action.payload;
 
             state.models = savedState.models;
-            state.selectedModelId = state.models.length > 0 ? state.models[0].id : undefined;
+            state.selectedModelId = savedState.selectedModelId;
             state.testedModels = []; // models should be tested again
 
             //state.table = undefined;

--- a/src/views/DataFormulator.tsx
+++ b/src/views/DataFormulator.tsx
@@ -54,7 +54,7 @@ export const DataFormulatorFC = ({ }) => {
     const displayPanelSize = useSelector((state: DataFormulatorState) => state.displayPanelSize);
     const visPaneSize = useSelector((state: DataFormulatorState) => state.visPaneSize);
     const tables = useSelector((state: DataFormulatorState) => state.tables);
-    const selectedModel = useSelector((state: DataFormulatorState) => state.selectedModel);
+    const selectedModelId = useSelector((state: DataFormulatorState) => state.selectedModelId);
 
     const dispatch = useDispatch();
 
@@ -173,15 +173,14 @@ Totals (7 entries)	5	5	5	15
                 href="https://privacy.microsoft.com/en-US/data-privacy-notice">view data privacy notice</Button>
     </Box>;
 
-    console.log("selected model?")
-    console.log(selectedModel)
 
+    console.log("selected model?")
+    console.log(selectedModelId)
+    
     return (
         <Box sx={{ display: 'block', width: "100%", height: 'calc(100vh - 49px)' }}>
             <DndProvider backend={HTML5Backend}>
-                {selectedModel == undefined ? modelSelectionDialogBox : (tables.length > 0 ? fixedSplitPane : dataUploadRequestBox)} 
+                {selectedModelId == undefined ? modelSelectionDialogBox : (tables.length > 0 ? fixedSplitPane : dataUploadRequestBox)} 
             </DndProvider>
-            
-
         </Box>);
 }

--- a/src/views/EncodingBox.tsx
+++ b/src/views/EncodingBox.tsx
@@ -594,7 +594,7 @@ export const EncodingBox: FC<EncodingBoxProps> = function EncodingBox({ channel,
         }}
         freeSolo
         renderInput={(params) => (
-            <TextField {...params} variant="standard" autoComplete='off' placeholder='field or concept'
+            <TextField {...params} variant="standard" autoComplete='off' placeholder='field'
                 sx={{height: "24px", "& .MuiInput-root": {height: "24px", fontSize: "small"}}} />
         )}
     />

--- a/src/views/EncodingShelfCard.tsx
+++ b/src/views/EncodingShelfCard.tsx
@@ -328,7 +328,7 @@ export const EncodingShelfCard: FC<EncodingShelfCardProps> = function ({ chartId
                             dispatch(dfActions.addMessages({
                                 "timestamp": Date.now(),
                                 "type": "error",
-                                "value": `Data formulation failed, please retry.`,
+                                "value": `Data formulation failed, please try again.`,
                                 "code": code,
                                 "detail": errorMessage
                             }));

--- a/src/views/EncodingShelfThread.tsx
+++ b/src/views/EncodingShelfThread.tsx
@@ -405,7 +405,7 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
 
     //let triggers = currentTable.derive.triggers;
     let tableList = activeTableThread.map((tableId) => <div
-        key={tableId}
+        key={`${tableId}-table-list-item`}
         className="table-list-item">
         <Button variant="text" sx={{textTransform: 'none', padding: 0, minWidth: 0}} onClick={() => { dispatch(dfActions.setFocusedTable(tableId)) }}>
             <Stack direction="row" sx={{fontSize: '12px'}} alignItems="center" gap={"2px"}>
@@ -419,7 +419,7 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
 
     let tableCards = activeTableThread.map((tableId) => 
         <Card 
-            key={tableId}
+            key={`${tableId}-table-card`}
             variant='outlined' sx={{padding: '2px 0 2px 0'}}>
             <Button variant="text" sx={{textTransform: 'none', padding: 0, marginLeft: 1, minWidth: 0}} onClick={() => { dispatch(dfActions.setFocusedTable(tableId)) }}>
                 <Stack direction="row" sx={{fontSize: '12px'}} alignItems="center" gap={"2px"}>
@@ -444,7 +444,7 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
         let fieldsIdentical = _.isEqual(previousActiveFields, currentActiveFields)
 
         return  <Box 
-                    key={trigger.tableId}
+                    key={`${trigger.tableId}-trigger-card`}
                     sx={{padding: 0, display: 'flex'}}>
                     {/* <SouthIcon sx={{fontSize: "inherit", margin: 'auto 4px'}} /> */}
                     <Box sx={{minWidth: '1px', padding: '0px', width: '17px',  flex: 'none', display: 'flex', flexDirection: 'column'

--- a/src/views/MessageSnackbar.tsx
+++ b/src/views/MessageSnackbar.tsx
@@ -168,15 +168,8 @@ export function MessageSnackbar() {
                         <Divider textAlign="left" sx={{my: 1, fontSize: 12, opacity: 0.7}} > [details] </Divider>
                     : ""}
                     {message?.detail ? 
-                        <Box
-                            sx={{
-                                borderRadius: 1,
-                                position: 'relative'
-                            }}
-                        >
-                            <Typography fontSize={12} >
-                                    {message?.detail}
-                            </Typography>
+                        <Box sx={{ borderRadius: 1, position: 'relative' }} >
+                            <Typography fontSize={12} > {message?.detail} </Typography>
                         </Box>
                     : ""}
                     {message?.code ? 

--- a/src/views/MessageSnackbar.tsx
+++ b/src/views/MessageSnackbar.tsx
@@ -8,7 +8,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import { DataFormulatorState, dfActions } from '../app/dfSlice';
 import { useDispatch, useSelector } from 'react-redux';
-import { Alert, alpha, Box, Paper, Tooltip, Typography } from '@mui/material';
+import { Alert, alpha, Box, Divider, Paper, Tooltip, Typography } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 
@@ -156,38 +156,38 @@ export function MessageSnackbar() {
             </Snackbar> : ""}
             {message != undefined ? <Snackbar
                 open={open && message != undefined}
-                autoHideDuration={message?.type == "error" ? 15000 : 5000}
+                autoHideDuration={message?.type == "error" ? 20000 : 10000}
                 anchorOrigin={{vertical: 'bottom', horizontal: 'right'}}
                 onClose={handleClose}
                 action={action}
             >
-                <Alert onClose={handleClose} severity={message?.type} sx={{ maxWidth: '400px' }}>
+                <Alert icon={false} onClose={handleClose} severity={message?.type} sx={{ maxWidth: '400px' }}>
                     <Typography fontSize={10} component="span" sx={{margin: "auto", opacity: 0.7}}>[{timestamp}]</Typography>  &nbsp;
-                    {message?.value} 
+                    <Typography fontSize={12} component="span" sx={{margin: "auto", fontWeight: 'bold'}}>{message?.value}</Typography> 
                     {message?.detail ? 
-                        <>
-                            <br />
-                            <Typography fontSize={12} component="span" sx={{marginBottom: 0, fontWeight: 'bold'}}>
-                                [error details]
+                        <Divider textAlign="left" sx={{my: 1, fontSize: 12, opacity: 0.7}} > [details] </Divider>
+                    : ""}
+                    {message?.detail ? 
+                        <Box
+                            sx={{
+                                borderRadius: 1,
+                                position: 'relative'
+                            }}
+                        >
+                            <Typography fontSize={12} >
+                                    {message?.detail}
                             </Typography>
-                            <br />
-                            <Typography fontSize={12} component="span" sx={{margin: "auto", opacity: 0.7}}>
-                                {message?.detail}   
-                            </Typography>
-                        </>
+                        </Box>
                     : ""}
                     {message?.code ? 
-                        <>
-                            <br />
-                            <Typography fontSize={12} component="span" sx={{marginBottom: 0, fontWeight: 'bold'}}>
-                                [generated code]
-                            </Typography>
-                            <Typography fontSize={10} component="span" sx={{margin: "auto", opacity: 0.7}}>
-                                <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginTop: 1 }}>
-                                    {message?.code?.split('\n').filter(line => line.trim() !== '').join('\n')}
-                                </pre>
-                            </Typography>
-                        </>
+                        <Divider textAlign="left" sx={{my: 1, fontSize: 12, opacity: 0.7}} > [generated code] </Divider>
+                    : ""}
+                    {message?.code ? 
+                        <Typography fontSize={10} component="span" sx={{margin: "auto", opacity: 0.7}}>
+                            <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginTop: 1 }}>
+                                {message?.code?.split('\n').filter(line => line.trim() !== '').join('\n')}
+                            </pre>
+                        </Typography>
                     : ""}
                 </Alert>    
             </Snackbar> : ""}

--- a/src/views/ModelSelectionDialog.tsx
+++ b/src/views/ModelSelectionDialog.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import '../scss/App.scss';
 
 import { useDispatch, useSelector } from "react-redux";
@@ -90,16 +90,16 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
         return testedModels.find(t => (t.id == id))?.status || 'unknown';
     }
 
-    const [newEndpoint, setNewEndpoint] = useState<string>(""); // openai, azure_openai, ollama etc
+    const [newEndpoint, setNewEndpoint] = useState<string>(""); // openai, azure, ollama etc
     const [newModel, setNewModel] = useState<string>("");
     const [newApiKey, setNewApiKey] = useState<string | undefined>(undefined);
     const [newApiBase, setNewApiBase] = useState<string | undefined>(undefined);
     const [newApiVersion, setNewApiVersion] = useState<string | undefined>(undefined);
 
-    let disableApiKey = newEndpoint == "default" || newEndpoint == "" || newEndpoint == "ollama";
-    let disableModel = newEndpoint == "default" || newEndpoint == "";
-    let disableApiBase = newEndpoint != "azure_openai";
-    let disableApiVersion = newEndpoint != "azure_openai";
+    let disableApiKey = newEndpoint == "" || newEndpoint == "ollama";
+    let disableModel = newEndpoint == "";
+    let disableApiBase = newEndpoint != "azure";
+    let disableApiVersion = newEndpoint != "azure";
 
     let modelExists = models.some(m => m.endpoint == newEndpoint && m.model == newModel && m.api_base == newApiBase && m.api_key == newApiKey && m.api_version == newApiVersion);
 
@@ -123,13 +123,10 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
     }
 
     let readyToTest = false;
-    if (newEndpoint != "default") {
-        readyToTest = true;
-    }
     if (newEndpoint == "openai") {
         readyToTest = newModel != "";
     }
-    if (newEndpoint == "azure_openai") {
+    if (newEndpoint == "azure") {
         readyToTest = newModel != "" && newApiBase != "";
     }
     if (newEndpoint == "ollama") {
@@ -153,11 +150,11 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                     if (newModel == "" && newValue == "openai") {
                         setNewModel("gpt-4o");
                     }
-                    if (!newApiVersion && newValue == "azure_openai") {
+                    if (!newApiVersion && newValue == "azure") {
                         setNewApiVersion("2024-02-15");
                     }
                 }}
-                options={['openai', 'azure_openai', 'ollama', 'gemini', 'anthropic']}
+                options={['openai', 'azure', 'ollama', 'gemini', 'anthropic']}
                 renderOption={(props, option) => (
                     <Typography {...props} onClick={() => setNewEndpoint(option)} sx={{fontSize: "0.875rem"}}>
                         {option}
@@ -203,7 +200,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                 disabled={disableModel}
                 onChange={(event: any, newValue: string | null) => { setNewModel(newValue || ""); }}
                 value={newModel}
-                options={['gpt-35-turbo', 'gpt-4', 'gpt-4o', 'llama3.2']}
+                options={['gpt-4o-mini', 'gpt-4', 'llama3.2']}
                 renderOption={(props, option) => {
                     return <Typography {...props} onClick={()=>{ setNewModel(option); }} sx={{fontSize: "small"}}>{option}</Typography>
                 }}
@@ -241,7 +238,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                 value={newApiBase}  onChange={(event: any) => { setNewApiBase(event.target.value); }} 
                 autoComplete='off'
                 disabled={disableApiBase}
-                required={newEndpoint == "azure_openai"}
+                required={newEndpoint == "azure"}
             />
         </TableCell>
         <TableCell align="right">
@@ -419,7 +416,8 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                 {newModelEntry}
                 <TableRow>
                     <TableCell colSpan={8} align="left" sx={{fontSize: "0.625rem"}}>
-                        model configuration based on LiteLLM, check out supported endpoint / model configurations <a href="https://docs.litellm.ai/docs/" target="_blank" rel="noopener noreferrer">here.</a>
+                        Model configuration based on LiteLLM,  <a href="https://docs.litellm.ai/docs/" target="_blank" rel="noopener noreferrer">check out supported endpoint / models here</a>. 
+                        Models with limited code generation capabilities (e.g., llama3.2) may fail frequently to derive new data.
                     </TableCell>
                 </TableRow>
             </TableBody>

--- a/src/views/ModelSelectionDialog.tsx
+++ b/src/views/ModelSelectionDialog.tsx
@@ -192,7 +192,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
             <TextField fullWidth size="small" type={showKeys ? "text" : "password"} 
                 InputProps={{ style: { fontSize: "0.875rem" } }} 
                 placeholder='leave blank if using keyless access'
-                error={!(newEndpoint == "azure" || newEndpoint == "ollama") && !newApiKey}
+                error={!(newEndpoint == "azure" || newEndpoint == "ollama" || newEndpoint == "") && !newApiKey}
                 value={newApiKey}  onChange={(event: any) => { setNewApiKey(event.target.value); }} 
                 autoComplete='off'
             />

--- a/src/views/ModelSelectionDialog.tsx
+++ b/src/views/ModelSelectionDialog.tsx
@@ -114,7 +114,9 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
         }
     }, [newEndpoint]);
 
-    let modelExists = models.some(m => m.endpoint == newEndpoint && m.model == newModel && m.api_base == newApiBase && m.api_key == newApiKey && m.api_version == newApiVersion);
+    let modelExists = models.some(m => 
+        m.endpoint == newEndpoint && m.model == newModel && m.api_base == newApiBase 
+        && m.api_key == newApiKey && m.api_version == newApiVersion);
 
     let testModel = (model: ModelConfig) => {
         updateModelStatus(model, 'testing', "");
@@ -158,7 +160,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                         setNewApiVersion("2024-02-15");
                     }
                 }}
-                options={['openai', 'azure', 'ollama', 'gemini', 'anthropic']}
+                options={['openai', 'azure', 'ollama', 'anthropic', 'gemini']}
                 renderOption={(props, option) => (
                     <Typography {...props} onClick={() => setNewEndpoint(option)} sx={{fontSize: "0.875rem"}}>
                         {option}
@@ -193,7 +195,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
             <TextField fullWidth size="small" type={showKeys ? "text" : "password"} 
                 InputProps={{ style: { fontSize: "0.875rem" } }} 
                 placeholder='leave blank if using keyless access'
-                error={newEndpoint != "azure" && !newApiKey}
+                error={!(newEndpoint == "azure" || newEndpoint == "ollama") && !newApiKey}
                 value={newApiKey}  onChange={(event: any) => { setNewApiKey(event.target.value); }} 
                 autoComplete='off'
             />


### PR DESCRIPTION
Support running models beyond open ai models
* you can provide model in the model_selection dialog as follows, we have tested with openai, azure, anthropic, ollama (codellama:7b, llama3.2)
* you also also refer to https://github.com/microsoft/data-formulator/blob/dev/py-src/data_formulator/agents/client_utils.py on how they are implemented with LiteLLM
* To preload credential to data formulator, provide them via `api-keys.env`, checkout https://github.com/microsoft/data-formulator/blob/dev/api-keys.env.template. Data Formulator will test and load them into the tool on start.

<img width="1526" alt="image" src="https://github.com/user-attachments/assets/33bc12f2-832e-4a5a-b39c-97c07d9ebbe2" />
