### PR TITLE
Prepare for the next update: Data Anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Transform data and create rich visualizations iteratively with AI 🪄. Try Data
 
 ## News 🔥🔥🔥
 
-- [03-20-2025] Data Formulator 0.1.7
-  - Anchor an intermediate dataset, so that followup data analysis are built on top of the anchored data, not the original one. It could be handy when you clean a data, and only want to use the cleaned data for followup analysis; when you want to create a subset from the original data or join multiple data together, and then focus your analysis. The AI agent will be less likely to get confused and work faster. ⚡️
-  - Fixed some performane issues from the UI (let us know if it is smoother).
-  - Don't forget to update Data Formulator to test it out.
+- [03-20-2025] Data Formulator 0.1.7: Anchoring ⚓︎
+  - Anchor an intermediate dataset, so that followup data analysis are built on top of the anchored data, not the original one.
+  - It is handy when: clean a data and work with only the cleaned data; create a subset from the original data or join multiple data, and then focus your analysis from there. The AI agent will be less likely to get confused and work faster. ⚡️⚡️
+  - Don't forget to update Data Formulator to test it out!
 
 - [02-20-2025] Data Formulator 0.1.6 released! 
   - Now supports working with multiple datasets at once! Tell Data Formulator which data tables you would like to use in the encoding shelf, and it will figure out how to join the tables to create a visualization to answer your question. 🪄

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Transform data and create rich visualizations iteratively with AI 🪄. Try Data
 
 ## News 🔥🔥🔥
 
+- [03-20-2025] Data Formulator 0.1.7
+  - Anchor an intermediate dataset, so that followup data analysis are built on top of the anchored data, not the original one. It could be handy when you clean a data, and only want to use the cleaned data for followup analysis; when you want to create a subset from the original data or join multiple data together, and then focus your analysis. The AI agent will be less likely to get confused and work faster. ⚡️
+  - Fixed some performane issues from the UI (let us know if it is smoother).
+  - Don't forget to update Data Formulator to test it out.
+
 - [02-20-2025] Data Formulator 0.1.6 released! 
   - Now supports working with multiple datasets at once! Tell Data Formulator which data tables you would like to use in the encoding shelf, and it will figure out how to join the tables to create a visualization to answer your question. 🪄
   - Checkout the demo at [[https://github.com/microsoft/data-formulator/releases/tag/0.1.6]](https://github.com/microsoft/data-formulator/releases/tag/0.1.6).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data_formulator"
-version = "0.1.6.2"
+version = "0.1.7"
 
 requires-python = ">=3.9"
 authors = [

--- a/src/app/dfSlice.tsx
+++ b/src/app/dfSlice.tsx
@@ -142,9 +142,11 @@ let deleteChartsRoutine = (state: DataFormulatorState, chartIds: string[]) => {
     state.activeThreadChartId = activeThreadChartId;
 
     let unrefedDerivedTableIds = getUnrefedDerivedTableIds(state);
-    state.tables = state.tables.filter(t => !unrefedDerivedTableIds.includes(t.id));
+    let tableIdsToDelete = state.tables.filter(t => !t.anchored && unrefedDerivedTableIds.includes(t.id)).map(t => t.id);
+    
+    state.tables = state.tables.filter(t => !tableIdsToDelete.includes(t.id));
     // remove intermediate charts that lead to this table
-    state.charts = state.charts.filter(c => !(c.intermediate && unrefedDerivedTableIds.includes(c.intermediate.resultTableId)));
+    state.charts = state.charts.filter(c => !(c.intermediate && tableIdsToDelete.includes(c.intermediate.resultTableId)));
 }
 
 export const fetchFieldSemanticType = createAsyncThunk(
@@ -376,18 +378,6 @@ export const dataFormulatorSlice = createSlice({
             state.charts = state.charts.map(chart => {
                 if (chart.id == chartId) {
                     return { ...chart, saved: !chart.saved };
-                } else {
-                    return chart;
-                }
-            })
-        },
-        updateChartScaleFactor: (state, action: PayloadAction<{chartId: string, scaleFactor: number}>) => {
-            let chartId = action.payload.chartId;
-            let scaleFactor = action.payload.scaleFactor;
-
-            state.charts = state.charts.map(chart => {
-                if (chart.id == chartId) {
-                    return { ...chart, scaleFactor: scaleFactor };
                 } else {
                     return chart;
                 }

--- a/src/app/dfSlice.tsx
+++ b/src/app/dfSlice.tsx
@@ -340,6 +340,11 @@ export const dataFormulatorSlice = createSlice({
             let anchored = action.payload.anchored;
             state.tables = state.tables.map(t => t.id == tableId ? {...t, anchored} : t);
         },
+        updateTableDisplayId: (state, action: PayloadAction<{tableId: string, displayId: string}>) => {
+            let tableId = action.payload.tableId;
+            let displayId = action.payload.displayId;
+            state.tables = state.tables.map(t => t.id == tableId ? {...t, displayId} : t);
+        },
         addChallenges: (state, action: PayloadAction<{tableId: string, challenges: { text: string; difficulty: 'easy' | 'medium' | 'hard'; }[]}>) => {
             state.activeChallenges = [...state.activeChallenges, action.payload];
         },

--- a/src/app/dfSlice.tsx
+++ b/src/app/dfSlice.tsx
@@ -335,6 +335,11 @@ export const dataFormulatorSlice = createSlice({
             // separate this, so that we only delete on tier of table a time
             state.charts = state.charts.filter(c => !(c.intermediate && c.intermediate.resultTableId == tableId));
         },
+        updateTableAnchored: (state, action: PayloadAction<{tableId: string, anchored: boolean}>) => {
+            let tableId = action.payload.tableId;
+            let anchored = action.payload.anchored;
+            state.tables = state.tables.map(t => t.id == tableId ? {...t, anchored} : t);
+        },
         addChallenges: (state, action: PayloadAction<{tableId: string, challenges: { text: string; difficulty: 'easy' | 'medium' | 'hard'; }[]}>) => {
             state.activeChallenges = [...state.activeChallenges, action.payload];
         },

--- a/src/app/utils.tsx
+++ b/src/app/utils.tsx
@@ -549,10 +549,21 @@ export const resolveChartFields = (chart: Chart, currentConcepts: FieldItem[], r
 }
 
 export let getTriggers = (leafTable: DictTable, tables: DictTable[]) => {
-    // recursively find triggers that ends in leafTable
+    // recursively find triggers that ends in leafTable (if the leaf table is anchored, we will find till the previous table is anchored)
     let triggers : Trigger[] = [];
     let t = leafTable;
-    while(t.derive != undefined) {
+    while(true) {
+
+        // this is when we find an original table
+        if (t.derive == undefined) {
+            break;
+        }
+
+        // this is when we find an anchored table (which is not the leaf table)
+        if (t !== leafTable && t.anchored) {
+            break;
+        }
+
         let trigger = t.derive.trigger as Trigger;
         triggers = [trigger, ...triggers];
         let parentTable = tables.find(x => x.id == trigger.tableId);

--- a/src/components/ComponentType.tsx
+++ b/src/components/ComponentType.tsx
@@ -100,7 +100,6 @@ export type Chart = {
     encodingMap: EncodingMap, 
     tableRef: string, 
     saved: boolean,
-    scaleFactor?: number,
     intermediate?: Trigger // whether this chart is only an intermediate chart (e.g., only used as a spec for transforming tables)
 }
 

--- a/src/components/ComponentType.tsx
+++ b/src/components/ComponentType.tsx
@@ -20,9 +20,10 @@ export interface FieldItem {
     type: Type;
     source: FieldSource;
     domain: any[];
+    tableRef: string; // which table it belongs to, it matters when it's an original field or a derived field
+
     transform?: ConceptTransformation;
-    tableRef?: string; // which table it comes from, it matters when it's an original field
-    temporary?: true;
+    temporary?: true; // the field is temporary, and it will be deleted unless it's saved
     levels?: {values: any[], reason: string}; // the order in which values in this field would be sorted
     semanticType?: string; // the semantic type of the object, inferred by the model
 }
@@ -69,13 +70,15 @@ export interface DictTable {
         // source specifies how the deriviation is done from the source tables, they may be the same, but not necessarily
         // in fact, right now dict tables are all triggered from charts
         trigger: Trigger,
-    }
+    };
+    anchored: boolean; // whether this table is anchored as a persistent table used to derive other tables
 }
 
 export function createDictTable(
     id: string, rows: any[], 
     derive: {code: string, codeExpl: string, source: string[], dialog: any[], 
-             trigger: Trigger} | undefined = undefined) : DictTable {
+             trigger: Trigger} | undefined = undefined,
+    anchored: boolean = false) : DictTable {
     
     let names = Object.keys(rows[0])
 
@@ -85,6 +88,7 @@ export function createDictTable(
         rows,
         types: names.map(name => inferTypeFromValueArray(rows.map(r => r[name]))),
         derive,
+        anchored
     }
 }
 

--- a/src/components/ComponentType.tsx
+++ b/src/components/ComponentType.tsx
@@ -57,6 +57,7 @@ export interface Trigger {
 
 export interface DictTable {
     id: string; // name/id of the table
+    displayId: string; // display id of the table 
     names: string[]; // column names
     types: Type[]; // column types
     rows: any[]; // table content, each entry is a row
@@ -84,6 +85,7 @@ export function createDictTable(
 
     return {
         id,
+        displayId: `${id}`,
         names, 
         rows,
         types: names.map(name => inferTypeFromValueArray(rows.map(r => r[name]))),

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -18,7 +18,7 @@ export const loadTextDataWrapper = (title: string, text: string, fileType: strin
     if (fileType == "text/csv" || fileType == "text/tab-separated-values") {
         table = createTableFromText(tableName, text);
     } else if (fileType == "application/json") {
-        table = createTableFromFromObjectArray(tableName, JSON.parse(text));
+        table = createTableFromFromObjectArray(tableName, JSON.parse(text), true);
     } 
     return table;
 };
@@ -52,10 +52,10 @@ export const createTableFromText = (title: string, text: string): DictTable | un
             return row;
           });
     
-    return createTableFromFromObjectArray(title, values);
+    return createTableFromFromObjectArray(title, values, true);
 };
 
-export const createTableFromFromObjectArray = (title: string, values: any[], derive?: any, anchored?: boolean): DictTable => {
+export const createTableFromFromObjectArray = (title: string, values: any[], anchored: boolean, derive?: any): DictTable => {
     const len = values.length;
     let names: string[] = [];
     let cleanNames: string[] = [];
@@ -99,7 +99,7 @@ export const createTableFromFromObjectArray = (title: string, values: any[], der
         types: columnTable.names().map(name => (columnTable.column(name) as Column).type),
         rows: columnTable.objects(),
         derive: derive,
-        anchored: false
+        anchored: anchored
     }
 };
 
@@ -172,7 +172,7 @@ export const loadBinaryDataWrapper = (title: string, arrayBuffer: ArrayBuffer): 
             const jsonData = XLSX.utils.sheet_to_json(worksheet);
             
             // Create a table from the JSON data with sheet name included in the title
-            const sheetTable = createTableFromFromObjectArray(`${title}-${sheetName}`, jsonData);
+            const sheetTable = createTableFromFromObjectArray(`${title}-${sheetName}`, jsonData, true);
             tables.push(sheetTable);
         }
         

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -55,7 +55,7 @@ export const createTableFromText = (title: string, text: string): DictTable | un
     return createTableFromFromObjectArray(title, values);
 };
 
-export const createTableFromFromObjectArray = (title: string, values: any[], derive?: any): DictTable => {
+export const createTableFromFromObjectArray = (title: string, values: any[], derive?: any, anchored?: boolean): DictTable => {
     const len = values.length;
     let names: string[] = [];
     let cleanNames: string[] = [];
@@ -98,7 +98,8 @@ export const createTableFromFromObjectArray = (title: string, values: any[], der
         names: columnTable.names(),
         types: columnTable.names().map(name => (columnTable.column(name) as Column).type),
         rows: columnTable.objects(),
-        derive: derive
+        derive: derive,
+        anchored: false
     }
 };
 

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -95,6 +95,7 @@ export const createTableFromFromObjectArray = (title: string, values: any[], anc
 
     return  {
         id: title,
+        displayId: `${title}`,
         names: columnTable.names(),
         types: columnTable.names().map(name => (columnTable.column(name) as Column).type),
         rows: columnTable.objects(),

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -92,3 +92,14 @@ h2.view-title {
 .Resizer.disabled:hover {
     border-color: transparent;
 }
+
+.GroupHeader {
+    position: sticky;
+    padding: 4px 8px;
+    color: rgba(0, 0, 0, 0.6);
+    font-size: 12px;
+}
+
+.GroupItems {
+    padding: 0;
+}

--- a/src/scss/EncodingShelf.scss
+++ b/src/scss/EncodingShelf.scss
@@ -23,7 +23,7 @@
 
 .encoding-shelf-trigger-card {
     margin: 6px 2px;
-    min-width: 160px;
+    min-width: 80px;
 }
 
 .encoding-shelf-compact {

--- a/src/scss/VisualizationView.scss
+++ b/src/scss/VisualizationView.scss
@@ -152,12 +152,6 @@ $accelerate-ease: cubic-bezier(0.4, 0.0, 1, 1);
         animation: appear 0.5s ease-out;
     }
 
-    .focused-vega-thumbnail {
-        //background-color: blue;
-        box-shadow: 0 0 5px rgba(33,33,33,.3);
-        z-index: 1;
-    }
-
     .vega-thumbnail:hover {
         transform: translateY(1px);
         box-shadow: 0 0 3px rgba(33,33,33,.2);

--- a/src/views/ConceptShelf.tsx
+++ b/src/views/ConceptShelf.tsx
@@ -85,7 +85,7 @@ export const ConceptGroup: FC<{groupName: string, fields: FieldItem[]}> = functi
             {fields.map((field) => (
                 <ConceptCard key={`concept-card-${field.id}`} field={field} />
             ))}
-            {fields.length > 5 && !expanded && (
+            {fields.length > 6 && !expanded && (
                 <Box sx={{ 
                     position: 'relative', 
                     height: '40px',
@@ -99,11 +99,11 @@ export const ConceptGroup: FC<{groupName: string, fields: FieldItem[]}> = functi
                         background: 'linear-gradient(to bottom, transparent, white)'
                     }
                 }}>
-                    <ConceptCard field={fields[5]} />
+                    <ConceptCard field={fields[6]} />
                 </Box>
             )}
         </Box>
-        {fields.length > 5 && !expanded && (
+        {fields.length > 6 && !expanded && (
             <Button
                 onClick={() => setExpanded(!expanded)}
                 sx={{
@@ -165,7 +165,7 @@ export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
     }, [focusedTableId])
     
     // group concepts based on types
-    let conceptItemGroups = groupConceptItems(conceptShelfItems);
+    let conceptItemGroups = groupConceptItems(conceptShelfItems, tables);
     let groupNames = [...new Set(conceptItemGroups.map(g => g.group))]
 
     return (

--- a/src/views/ConceptShelf.tsx
+++ b/src/views/ConceptShelf.tsx
@@ -31,7 +31,7 @@ import { OperatorCard } from './OperatorCard';
 export const genFreshCustomConcept : () => FieldItem = () => {
     return {
         id: `concept-${Date.now()}`, name: "", type: "auto" as Type, domain: [],
-        description: "", source: "custom",
+        description: "", source: "custom", tableRef: "custom",
     }
 }
 
@@ -43,28 +43,98 @@ export interface ConceptShelfProps {
     
 }
 
+export const ConceptGroup: FC<{groupName: string, fields: FieldItem[]}> = function ConceptGroup({groupName, fields}) {
+
+    const focusedTableId = useSelector((state: DataFormulatorState) => state.focusedTableId);
+    const [expanded, setExpanded] = useState(false);
+
+    useEffect(() => {
+        if (focusedTableId == groupName) {
+            setExpanded(true);
+        } else if (focusedTableId != groupName && groupName != "new fields") {
+            setExpanded(false);
+        }
+    }, [focusedTableId])
+
+    return <Box>
+        <Box sx={{display: "block", width: "100%"}}>
+            <Divider orientation="horizontal" textAlign="left">
+                <Box sx={{ 
+                    display: 'flex', 
+                    alignItems: 'center', 
+                    cursor: 'pointer' 
+                }}
+                    onClick={() => setExpanded(!expanded)}>
+                    <Typography component="h2" sx={{fontSize: "10px"}} color="text.secondary">
+                        {groupName}
+                    </Typography>
+                    <Typography sx={{fontSize: "10px", ml: 1}} color="text.secondary">
+                        {expanded ? '▾' : '▸'}
+                    </Typography>
+                </Box>
+            </Divider>
+        </Box>
+        <Box
+            sx={{
+                maxHeight: expanded ? 'auto' : '240px',
+                overflow: 'hidden',
+                transition: 'max-height 0.3s ease-in-out',
+                width: '100%'
+            }}
+        >
+            {fields.map((field) => (
+                <ConceptCard key={`concept-card-${field.id}`} field={field} />
+            ))}
+            {fields.length > 5 && !expanded && (
+                <Box sx={{ 
+                    position: 'relative', 
+                    height: '40px',
+                    '&::after': {
+                        content: '""',
+                        position: 'absolute',
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        height: '100%',
+                        background: 'linear-gradient(to bottom, transparent, white)'
+                    }
+                }}>
+                    <ConceptCard field={fields[5]} />
+                </Box>
+            )}
+        </Box>
+        {fields.length > 5 && !expanded && (
+            <Button
+                onClick={() => setExpanded(!expanded)}
+                sx={{
+                    fontSize: "10px",
+                    color: "text.secondary",
+                    pl: 2,
+                    py: 0.5,
+                    fontStyle: "italic",
+                    textTransform: 'none',
+                    '&:hover': {
+                        background: 'transparent',
+                        textDecoration: 'underline'
+                    }
+                }}
+            >
+                {`... show all ${fields.length} ${groupName} fields ▾`}
+            </Button>
+        )}
+    </Box>;
+}
+
 
 export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
 
-    let theme = useTheme();
     // reference to states
     const conceptShelfItems = useSelector((state: DataFormulatorState) => state.conceptShelfItems);
     const focusedTableId = useSelector((state: DataFormulatorState) => state.focusedTableId);
     const tables = useSelector((state: DataFormulatorState) => state.tables);
     const charts = useSelector((state: DataFormulatorState) => state.charts);
 
-    let [expandedGroups, setExpandedGroups] = useState<string[]>([]);
-    let updateExpandedGroup = (groupName: string, isExpanded: boolean) => {
-        if (isExpanded) {
-            setExpandedGroups([...expandedGroups, groupName]);
-        } else {
-            setExpandedGroups(expandedGroups.filter(g => g != groupName));
-        }
-    }
-
     const dispatch = useDispatch();
-    let handleDeleteConcept = (conceptID: string) => dispatch(dfActions.deleteConceptItemByID(conceptID));
-    let handleUpdateConcept = (field: FieldItem) => dispatch(dfActions.updateConceptItems(field));
 
     useEffect(() => { 
         let focusedTable = tables.find(t => t.id == focusedTableId);
@@ -75,7 +145,7 @@ export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
             let conceptsToAdd = missingNames.map((name) => {
                 return {
                     id: `concept-${name}-${Date.now()}`, name: name, type: "auto" as Type, 
-                    description: "", source: "custom", temporary: true, domain: [],
+                    description: "", source: "custom", tableRef: 'custom', temporary: true, domain: [],
                 } as FieldItem
             })
             dispatch(dfActions.addConceptItems(conceptsToAdd));
@@ -87,48 +157,13 @@ export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
             // add and delete temporary fields
             dispatch(dfActions.batchDeleteConceptItemByID(conceptIdsToDelete));
 
-
-            // update collapsed groups
-            let sourceTables = focusedTable.derive?.source || [focusedTable.id];
-            setExpandedGroups(sourceTables);
-
         } else {
             if (tables.length > 0) {
                 dispatch(dfActions.setFocusedTable(tables[0].id))
             }
         }
     }, [focusedTableId])
-
-
-    let conceptCreatorBtn = (
-        <Tooltip title="Create a new concept">
-            <Button
-                sx={{ fontSize: "14px", color: theme.palette.custom.main, '&:hover': { backgroundColor: alpha(theme.palette.custom.main, 0.1) },
-                      float: "right", textTransform: "none", minWidth: "20px", lineHeight: 1, padding: "0px 4px"}}
-                size="small"
-                aria-label="Create new concept"
-                endIcon={<AddCircleIcon fontSize="inherit" />}
-                onClick={() => {
-                    if (conceptShelfItems.filter(f => f.name === "").length > 0) {
-                        return
-                    }
-                    handleUpdateConcept(genFreshCustomConcept());
-                }}>
-                new
-            </Button>
-        </Tooltip>);
-
-    // // items for controlling icon creation
-    // const [fieldSelectorAnchorEl, setFieldSelectorAnchorEl] = React.useState<HTMLButtonElement | null>(null);
-    // const handleOpenFieldSelector = (event: React.MouseEvent<HTMLButtonElement>) => {
-    //     setFieldSelectorAnchorEl(event.currentTarget);
-    // };
-    // const handleCloseFieldSelector = () => { setFieldSelectorAnchorEl(null); };
- 
-    // define anchor open
-    // const fieldSelectorOpen = Boolean(fieldSelectorAnchorEl);
-    // const fieldSelectorId = fieldSelectorOpen ? `conceptCreator` : undefined;
-
+    
     // group concepts based on types
     let conceptItemGroups = groupConceptItems(conceptShelfItems);
     let groupNames = [...new Set(conceptItemGroups.map(g => g.group))]
@@ -139,7 +174,6 @@ export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
                 <Typography className="view-title" component="h2" sx={{marginTop: "6px"}}>
                     Data Fields
                 </Typography>
-                {conceptCreatorBtn}
             </Box>
             <Box className="data-fields-group">
                 <Box className="data-fields-list">
@@ -161,78 +195,7 @@ export const ConceptShelf: FC<ConceptShelfProps> = function ConceptShelf() {
                         let fields = conceptItemGroups.filter(g => g.group == groupName).map(g => g.field);
                         let isCustomGroup = groupName == "new fields";
 
-                        return (
-                            <>
-                                <Box sx={{display: "block", width: "100%"}}>
-                                    <Divider orientation="horizontal" textAlign="left">
-                                    <Box sx={{ 
-                                        display: 'flex', 
-                                        alignItems: 'center', 
-                                        cursor: !isCustomGroup ? 'pointer' : 'default' 
-                                    }}
-                                        onClick={() => !isCustomGroup && updateExpandedGroup(groupName, !expandedGroups.includes(groupName))}>
-                                        <Typography component="h2" sx={{fontSize: "10px"}} color="text.secondary">
-                                            {groupName}
-                                        </Typography>
-                                        {!isCustomGroup && (
-                                            <Typography sx={{fontSize: "10px", ml: 1}} color="text.secondary">
-                                                {expandedGroups.includes(groupName) ? '▾' : '▸'}
-                                            </Typography>
-                                        )}
-                                    </Box>
-                                </Divider>
-                            </Box>
-                            
-                            <Box
-                                sx={{
-                                    maxHeight: expandedGroups.includes(groupName) || isCustomGroup ? 'auto' : '240px',
-                                    overflow: 'hidden',
-                                    transition: 'max-height 0.3s ease-in-out',
-                                    width: '100%'
-                                }}
-                            >
-                                {(expandedGroups.includes(groupName) || isCustomGroup ? fields : fields.slice(0, 5)).map((field) => (
-                                    <ConceptCard key={`concept-card-${field.id}`} field={field} />
-                                ))}
-                                {!expandedGroups.includes(groupName) && !isCustomGroup && fields.length > 5 && (
-                                    <Box sx={{ 
-                                        position: 'relative', 
-                                        height: '40px',
-                                        '&::after': {
-                                            content: '""',
-                                            position: 'absolute',
-                                            bottom: 0,
-                                            left: 0,
-                                            right: 0,
-                                            height: '100%',
-                                            background: 'linear-gradient(to bottom, transparent, white)'
-                                        }
-                                    }}>
-                                        <ConceptCard field={fields[5]} />
-                                    </Box>
-                                )}
-                            </Box>
-                            {!expandedGroups.includes(groupName) && !isCustomGroup && fields.length > 5 && (
-                                <Button
-                                    onClick={() => updateExpandedGroup(groupName, true)}
-                                    sx={{
-                                        fontSize: "10px",
-                                        color: "text.secondary",
-                                        pl: 2,
-                                        py: 0.5,
-                                        fontStyle: "italic",
-                                        textTransform: 'none',
-                                        '&:hover': {
-                                            background: 'transparent',
-                                            textDecoration: 'underline'
-                                        }
-                                    }}
-                                >
-                                    {`... show all ${fields.length} ${groupName} fields ▾`}
-                                </Button>
-                            )}
-                            </>
-                        )
+                        return <ConceptGroup key={`concept-group-${groupName}`} groupName={groupName} fields={fields} />
                     })}
                     <Divider orientation="horizontal" textAlign="left" sx={{mt: 1}}></Divider>
                 </Box>

--- a/src/views/ConceptShelf.tsx
+++ b/src/views/ConceptShelf.tsx
@@ -46,10 +46,12 @@ export interface ConceptShelfProps {
 export const ConceptGroup: FC<{groupName: string, fields: FieldItem[]}> = function ConceptGroup({groupName, fields}) {
 
     const focusedTableId = useSelector((state: DataFormulatorState) => state.focusedTableId);
+    const tables = useSelector((state: DataFormulatorState) => state.tables);
     const [expanded, setExpanded] = useState(false);
 
     useEffect(() => {
-        if (focusedTableId == groupName) {
+        let focusedTable = tables.find(t => t.id == focusedTableId);
+        if (focusedTableId == groupName || focusedTable?.derive?.source.includes(groupName)) {
             setExpanded(true);
         } else if (focusedTableId != groupName && groupName != "new fields") {
             setExpanded(false);

--- a/src/views/DataFormulator.tsx
+++ b/src/views/DataFormulator.tsx
@@ -42,11 +42,6 @@ import dfLogo from '../assets/df-logo.png';
 import exampleImageTable from "../assets/example-image-table.png";
 import { ModelSelectionButton } from './ModelSelectionDialog';
 
-const MainSplitPane = styled(SplitPane)(({ theme }) => ({
-    //height: 'calc(100% - 49px) !important',
-    //left: '121px !important'
-}));
-
 //type AppProps = ConnectedProps<typeof connector>;
 
 export const DataFormulatorFC = ({ }) => {
@@ -89,7 +84,7 @@ export const DataFormulatorFC = ({ }) => {
         </SplitPane>);
 
     const splitPane = ( // @ts-ignore
-        <MainSplitPane split="vertical"
+        <SplitPane split="vertical"
             maxSize={440}
             minSize={320}
             primary="second"
@@ -106,7 +101,7 @@ export const DataFormulatorFC = ({ }) => {
                 {conceptEncodingPanel}
                 {/* <InfoPanelFC $tableRef={$tableRef}/> */}
             </Box>
-        </MainSplitPane>);
+        </SplitPane>);
 
     const fixedSplitPane = ( 
         <Box sx={{display: 'flex', flexDirection: 'row', height: '100%'}}>

--- a/src/views/DataView.tsx
+++ b/src/views/DataView.tsx
@@ -95,7 +95,7 @@ export const FreeDataViewFC: FC<FreeDataViewProps> = function DataView({  $table
     let genTableLink =  (t: DictTable) => 
         <Link underline="hover" key={t.id} sx={{cursor: "pointer"}} 
             color="#1770c7" onClick={()=>{ dispatch(dfActions.setFocusedTable(t.id)) }}>
-            <Typography sx={{fontWeight: t.id == focusedTableId? "bold" : "inherit", fontSize: 'inherit'}} component='span'>{t.id}</Typography>
+            <Typography sx={{fontWeight: t.id == focusedTableId? "bold" : "inherit", fontSize: 'inherit'}} component='span'>{t.displayId || t.id}</Typography>
         </Link>;
 
     return (

--- a/src/views/DataView.tsx
+++ b/src/views/DataView.tsx
@@ -45,7 +45,7 @@ export const FreeDataViewFC: FC<FreeDataViewProps> = function DataView({  $table
             return tables.map(table => {
                 // try to let table figure out all fields are derivable from the table
                 let rows = baseTableToExtTable(table.rows, derivedFields, conceptShelfItems);
-                let extTable = createTableFromFromObjectArray(`${table.id}`, rows, table.derive);
+                let extTable = createTableFromFromObjectArray(`${table.id}`, rows, table.anchored, table.derive);
                 return extTable
             })
         } else {

--- a/src/views/DataView.tsx
+++ b/src/views/DataView.tsx
@@ -23,6 +23,7 @@ import { SelectableGroup } from 'react-selectable-fast';
 import { SelectableDataGrid } from './SelectableDataGrid';
 
 import ParkIcon from '@mui/icons-material/Park';
+import AnchorIcon from '@mui/icons-material/Anchor';
 
 export interface FreeDataViewProps {
     $tableRef: React.RefObject<SelectableGroup>;
@@ -89,8 +90,8 @@ export const FreeDataViewFC: FC<FreeDataViewProps> = function DataView({  $table
 
     let tableToRender = extTables; 
 
-    let coreTables = tableToRender.filter(t => t.derive == undefined);
-    let tempTables = tableToRender.filter(t => t.derive);
+    let coreTables = tableToRender.filter(t => t.derive == undefined || t.anchored);
+    let tempTables = tableToRender.filter(t => t.derive && !t.anchored);
 
     let genTableLink =  (t: DictTable) => 
         <Link underline="hover" key={t.id} sx={{cursor: "pointer"}} 
@@ -100,15 +101,14 @@ export const FreeDataViewFC: FC<FreeDataViewProps> = function DataView({  $table
 
     return (
         <Box sx={{height: "100%", display: "flex", flexDirection: "column", background: "rgba(0,0,0,0.02)"}}>
-            {/* <Box sx={{fontSize: "12px", margin: "4px 12px", display: 'flex'}}>
-                {coreTables.map((t, i) => [i > 0 ? <Divider orientation="vertical" sx={{margin: '0px 4px'}}/> : "", genTableLink(t)])}
-            </Box> */}
+
             <Box sx={{display: 'flex'}}>
+                <Typography sx={{display: 'flex', color: 'rgba(0,0,0,0.5)', ml: 1}} component='span'><AnchorIcon sx={{ fontSize: 14, margin: 'auto'}}/></Typography>
                 <Breadcrumbs sx={{fontSize: "12px", margin: "4px 12px"}} separator="·" aria-label="breadcrumb">
                     {coreTables.map(t => genTableLink(t))}
                 </Breadcrumbs>
                 {/* <Divider variant="inset" orientation="vertical" sx={{margin: '0px 4px'}} /> */}
-                <Typography sx={{display: 'flex', color: 'darkgray'}} component='span'><ParkIcon sx={{ fontSize: 14, margin: 'auto'}}/></Typography>
+                <Typography sx={{display: 'flex', color: 'rgba(0,0,0,0.5)', ml: 1}} component='span'><ParkIcon sx={{ fontSize: 14, margin: 'auto'}}/></Typography>
                 <Breadcrumbs sx={{fontSize: "12px", margin: "4px 12px"}} separator="·" aria-label="breadcrumb">
                     {tempTables.map(t => genTableLink(t))}
                 </Breadcrumbs>

--- a/src/views/DerivedDataDialog.tsx
+++ b/src/views/DerivedDataDialog.tsx
@@ -34,18 +34,6 @@ import { CustomReactTable } from './ReactTable';
 import DeleteIcon from '@mui/icons-material/Delete';
 import SaveIcon from '@mui/icons-material/Save';
 
-export const GroupHeader = styled('div')(({ theme }) => ({
-    position: 'sticky',
-    top: '-8px',
-    padding: '4px 4px',
-    color: "darkgray",
-    fontSize: "12px",
-}));
-  
-export const GroupItems = styled('ul')({
-    padding: 0,
-});
-
 export interface DerivedDataDialogProps {
     chart: Chart,
     candidateTables: DictTable[],

--- a/src/views/DisambiguationDialog.tsx
+++ b/src/views/DisambiguationDialog.tsx
@@ -33,18 +33,6 @@ import { CodexDialogBox } from './ConceptCard';
 import { CodeBox } from './VisualizationView';
 import { CustomReactTable } from './ReactTable';
 
-export const GroupHeader = styled('div')(({ theme }) => ({
-    position: 'sticky',
-    top: '-8px',
-    padding: '4px 4px',
-    color: "darkgray",
-    fontSize: "12px",
-}));
-  
-export const GroupItems = styled('ul')({
-    padding: 0,
-});
-
 export interface DisambiguationDialogProps {
     conceptName: string;
     parentIDs: string[];
@@ -201,11 +189,6 @@ export const DisambiguationDialog: FC<DisambiguationDialogProps> = function Disa
 
                         }
 
-                        
-
-                        
-                        
-
                         return <Card key={`candidate-dialog-${idx}`} onClick={()=>{setSelectionIdx(idx)}} 
                               sx={{minWidth: "280px", maxWidth: "600px", display: "flex",  flexGrow: 1, margin: "10px", 
                                    border: selectionIdx == idx ? "2px solid rgb(2 136 209 / 0.7)": "2px solid rgba(255, 255, 255, 0)"}}>
@@ -217,20 +200,20 @@ export const DisambiguationDialog: FC<DisambiguationDialogProps> = function Disa
                                         '& .MuiFormLabel-root': { fontSize: "inherit" } }}
                                     value={idx} control={<Radio checked={selectionIdx == idx} />} label={`candidate-${idx+1}`} />
                                 <Box width="100%" sx={{}}>
-                                    <GroupHeader>
-                                        <Typography style={{ fontSize: "12px" }}>transformation result on sample data</Typography>
-                                    </GroupHeader>
-                                    <GroupItems sx={{padding: "0px 10px", margin: 0}}>
+                                    <Box className="GroupHeader">
+                                        <Typography style={{ fontSize: "12px" }}>transformation result on sample data </Typography>
+                                    </Box>
+                                    <Box className="GroupItems" sx={{padding: "0px 10px", margin: 0}}>
                                         {/* <ExampleMappingTable ioPairList={codeOutputSamples} colNames={colNames} handlePageInc={handlePageInc} handlePageDesc={handlePageDesc}
                                             highlight={highlightedRows} numDisplayed={displayPageSize} /> */}
                                         <Box sx={{maxHeight: 300, minWidth: '200px', width: "100%", overflow: "auto", flexGrow: 1,fontSize: 10 }}>
                                             {simpleTableView(codeOutputs[idx], colNames, conceptShelfItems)}
                                         </Box>
-                                    </GroupItems>
+                                    </Box>
                                 </Box>
-                                <GroupHeader sx={{marginTop: 1}}>
+                                <Box className="GroupHeader" sx={{marginTop: 1}}>
                                     <Typography style={{ fontSize: "12px" }}>transformation code</Typography>
-                                </GroupHeader>
+                                </Box>
                                 <Box sx={{maxHeight: 280, width: "100%", overflow: "auto", flexGrow: 1 }}>
                                     <CodeBox code={formattedCode} language="typescript"/>
                                     {/* <Editor

--- a/src/views/EncodingBox.tsx
+++ b/src/views/EncodingBox.tsx
@@ -49,18 +49,7 @@ import { deriveTransformExamplesV2, getDomains, getIconFromType, groupConceptIte
 import { getUrls } from '../app/utils';
 import { Type } from '../data/types';
 
-const GroupHeader = styled('div')(({ theme }) => ({
-    position: 'sticky',
-    top: '-8px',
-    padding: '4px 10px',
-    fontSize: '10px',
-    color: 'darkgray',
-    //backgroundColor: 'rbga(0,0,0,0.6)'
-  }));
-  
-  const GroupItems = styled('ul')({
-    padding: 0,
-  });
+
 
 let getChannelDisplay = (channel: Channel) => {
     if (channel == "x") {
@@ -528,7 +517,7 @@ export const EncodingBox: FC<EncodingBoxProps> = function EncodingBox({ channel,
                 console.log(`about to add ${option}`)
                 let newConept = {
                     id: `concept-${Date.now()}`, name: option, type: "auto" as Type, 
-                    description: "", source: "custom", domain: [],
+                    description: "", source: "custom", domain: [], tableRef: "custom",
                 } as FieldItem;
                 dispatch(dfActions.updateConceptItems(newConept));
                 updateEncProp("fieldID", newConept.id);
@@ -579,10 +568,10 @@ export const EncodingBox: FC<EncodingBoxProps> = function EncodingBox({ channel,
             }         
         }}
         renderGroup={(params) => (
-            <li>
-              <GroupHeader>{params.group}</GroupHeader>
-              <GroupItems>{params.children}</GroupItems>
-            </li>
+            <Box>
+              <Box className="GroupHeader">{params.group}</Box>
+              <Box className="GroupItems">{params.children}</Box>
+            </Box>
           )}
         renderOption={(props, option) => {
             let renderOption = (conceptShelfItems.map(f => f.name).includes(option) || option == "...") ? option : `"${option}"`;

--- a/src/views/EncodingBox.tsx
+++ b/src/views/EncodingBox.tsx
@@ -526,7 +526,7 @@ export const EncodingBox: FC<EncodingBoxProps> = function EncodingBox({ channel,
         }
     }
 
-    let conceptGroups = groupConceptItems(conceptShelfItems);
+    let conceptGroups = groupConceptItems(conceptShelfItems, tables);
     let createConceptInputBox = <Autocomplete
         key="concept-create-input-box"
         onChange={(event, value) => {

--- a/src/views/EncodingShelfCard.tsx
+++ b/src/views/EncodingShelfCard.tsx
@@ -551,7 +551,7 @@ export const EncodingShelfCard: FC<EncodingShelfCardProps> = function ({ chartId
                             let conceptsToAdd = missingNames.map((name) => {
                                 return {
                                     id: `concept-${name}-${Date.now()}`, name: name, type: "auto" as Type, 
-                                    description: "", source: "custom", temporary: true, domain: [],
+                                    description: "", source: "custom", tableRef: "custom", temporary: true, domain: [],
                                 } as FieldItem
                             })
                             dispatch(dfActions.addConceptItems(conceptsToAdd));

--- a/src/views/EncodingShelfThread.tsx
+++ b/src/views/EncodingShelfThread.tsx
@@ -33,6 +33,7 @@ import { getChartTemplate } from '../components/ChartTemplates';
 import { chartAvailabilityCheck, generateChartSkeleton } from './VisualizationView';
 import TableRowsIcon from '@mui/icons-material/TableRowsOutlined';
 import InsightsIcon from '@mui/icons-material/Insights';
+import AnchorIcon from '@mui/icons-material/Anchor';
 
 import { findBaseFields } from './ViewUtils';
 import { AppDispatch } from '../app/store';
@@ -150,7 +151,6 @@ export let ChartElementFC: FC<{chart: Chart, tableRows: any[], boxWidth?: number
 
 export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ chartId }) {
 
-    // reference to states
     const tables = useSelector((state: DataFormulatorState) => state.tables);
     const charts = useSelector((state: DataFormulatorState) => state.charts);
     let activeThreadChartId = useSelector((state: DataFormulatorState) => state.activeThreadChartId);
@@ -221,11 +221,7 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
         }) 
         let engine = getUrls().SERVER_DERIVE_DATA_URL;
 
-        console.log("current log")
-        console.log(triggerTable.derive?.dialog)
-
-
-        if (mode == "formulate" && triggerTable.derive?.dialog) {
+        if (triggerTable.derive?.dialog && !triggerTable.anchored) {
             messageBody = JSON.stringify({
                 token: token,
                 mode,
@@ -404,36 +400,30 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
             });
     }
 
-    //let triggers = currentTable.derive.triggers;
-    let tableList = activeTableThread.map((tableId) => <div
-        key={`${tableId}-table-list-item`}
-        className="table-list-item">
-        <Button variant="text" sx={{textTransform: 'none', padding: 0, minWidth: 0}} onClick={() => { dispatch(dfActions.setFocusedTable(tableId)) }}>
-            <Stack direction="row" sx={{fontSize: '12px'}} alignItems="center" gap={"2px"}>
-                <TableRowsIcon fontSize="inherit" />
-                <Typography sx={{fontSize: '12px'}} >
-                    {tableId} 
-                </Typography>
-            </Stack>
-        </Button>
-    </div>);
-
-    let tableCards = activeTableThread.map((tableId) => 
-        <Card 
-            key={`${tableId}-table-card`}
-            variant='outlined' sx={{padding: '2px 0 2px 0'}}>
-            <Button variant="text" sx={{textTransform: 'none', padding: 0, marginLeft: 1, minWidth: 0}} onClick={() => { dispatch(dfActions.setFocusedTable(tableId)) }}>
+    let tableList = activeTableThread.map((tableId) => {
+        let table = tables.find(t => t.id == tableId) as DictTable;
+        return <div
+                key={`${tableId}-table-list-item`}
+                className="table-list-item">
+                <Button variant="text" sx={{textTransform: 'none', padding: 0, minWidth: 0}} onClick={() => { dispatch(dfActions.setFocusedTable(tableId)) }}>
                 <Stack direction="row" sx={{fontSize: '12px'}} alignItems="center" gap={"2px"}>
-                    <TableRowsIcon fontSize="inherit" />
+                    {table.anchored ? <AnchorIcon fontSize="inherit" /> : <TableRowsIcon fontSize="inherit" />}
                     <Typography sx={{fontSize: '12px'}} >
-                        {tableId} 
+                        {table.displayId || tableId}
                     </Typography>
                 </Stack>
             </Button>
-        </Card>);
+        </div>
+    });
+
 
     let leafTable = tables.find(t => t.id == activeTableThread[activeTableThread.length - 1]) as DictTable;
-    let triggers =  getTriggers(leafTable, tables) //leafTable.derive?.triggers || [];
+    let triggers =  getTriggers(leafTable, tables)
+
+
+    console.log('from local data thread')
+    console.log(triggers[triggers.length - 1]);
+
     let instructionCards = triggers.map((trigger, i) => {
         let extractActiveFields = (t: Trigger) => {
             let encodingMap = (charts.find(c => c.id == t.chartRef) as Chart).encodingMap
@@ -445,31 +435,25 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
         let fieldsIdentical = _.isEqual(previousActiveFields, currentActiveFields)
 
         return  <Box 
-                    key={`${trigger.tableId}-trigger-card`}
-                    sx={{padding: 0, display: 'flex'}}>
-                    {/* <SouthIcon sx={{fontSize: "inherit", margin: 'auto 4px'}} /> */}
-                    <Box sx={{minWidth: '1px', padding: '0px', width: '17px',  flex: 'none', display: 'flex', flexDirection: 'column'
-                              //borderLeft: '1px dashed darkgray',
-                            }}>
-                        <Box sx={{padding:0, width: '1px', margin:'auto', height: '100%',
-                                    backgroundImage: 'linear-gradient(180deg, darkgray, darkgray 75%, transparent 75%, transparent 100%)',
-                                    backgroundSize: '1px 6px, 3px 100%'}}></Box>
-                        {/* <Box sx={{marginLeft: "6px", marginTop: '-10px', marginBottom: '-4px'}}><PanoramaFishEyeIcon sx={{fontSize: 5}}/></Box>
-                        <Box sx={{padding:0, width: '1px', margin:'auto', height: '49%',
-                                               backgroundImage: 'linear-gradient(180deg, darkgray, darkgray 75%, transparent 75%, transparent 100%)',
-                            backgroundSize: '1px 6px, 3px 100%'}}></Box> */}
-                    </Box>
-                    <TriggerCard className="encoding-shelf-trigger-card" trigger={trigger} hideFields={fieldsIdentical} />
-                    {i == triggers.length - 1 && chart.intermediate == undefined ? 
-                        <Tooltip title={`reformulate: override ${chart.tableRef}`}>
-                            <IconButton color="warning" size="small"
-                                onClick={() => {
-                                    reFormulate(triggers[triggers.length - 1]);
-                                }}
-                            >{reformulateRunning ? <CircularProgress size={18} color="warning" /> : <ChangeCircleOutlinedIcon />}</IconButton>
-                        </Tooltip> 
-                        : ""}
-                </Box>;
+            key={`${trigger.tableId}-trigger-card`}
+            sx={{padding: 0, display: 'flex'}}>
+            <Box sx={{minWidth: '1px', padding: '0px', width: '17px',  flex: 'none', display: 'flex', flexDirection: 'column'
+                    }}>
+                <Box sx={{padding:0, width: '1px', margin:'auto', height: '100%',
+                            backgroundImage: 'linear-gradient(180deg, darkgray, darkgray 75%, transparent 75%, transparent 100%)',
+                            backgroundSize: '1px 6px, 3px 100%'}}></Box>
+            </Box>
+            <TriggerCard className="encoding-shelf-trigger-card" trigger={trigger} hideFields={fieldsIdentical} />
+            {i == triggers.length - 1 && chart.intermediate == undefined ? 
+                <Tooltip title={`reformulate: override ${chart.tableRef}`}>
+                    <IconButton color="warning" size="small"
+                        onClick={() => {
+                            reFormulate(triggers[triggers.length - 1]);
+                        }}
+                    >{reformulateRunning ? <CircularProgress size={18} color="warning" /> : <ChangeCircleOutlinedIcon />}</IconButton>
+                </Tooltip> 
+                : ""}
+        </Box>;
     })
     
     let spaceElement = "" //<Box sx={{padding: '4px 0px', background: 'aliceblue', margin: 'auto', width: '200px', height: '3px', paddingBottom: 0.5}}></Box>;
@@ -516,13 +500,6 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
                                                     backgroundSize: '1px 6px, 3px 100%'}}></Box>
                         </Box>, ...instructionCards.slice(cutIndex+1, postInstructEndPoint)], 
                         tableList.slice(cutIndex + 1, postInstructEndPoint + 1), spaceElement)}
-                    {/* {w(Array(tableList.length - (cutIndex) - 1).fill(
-                        <Box sx={{padding: '2px 0 2px 0', display: 'flex', alignItems: "center"}}>
-                            <SouthIcon sx={{fontSize: "inherit", margin: 'auto 4px'}} />
-                        </Box>), 
-                        tableList.slice(cutIndex + 1), spaceElement)} */}
-                    {/* {w(tableList.slice(0, tableList.length - 1), instructionList.slice(0, instructionList.length - 1))}  */}
-                    {/* <Button sx={{minWidth: '24px'}}><RestartAlt /></Button> */}
                 </Box>
                 <Box>
                     {endChartCard}

--- a/src/views/EncodingShelfThread.tsx
+++ b/src/views/EncodingShelfThread.tsx
@@ -313,7 +313,7 @@ export const EncodingShelfThread: FC<EncodingShelfThreadProps> = function ({ cha
                             let conceptsToAdd = missingNames.map((name) => {
                                 return {
                                     id: `concept-${name}-${Date.now()}`, name: name, type: "auto" as Type, 
-                                    description: "", source: "custom", temporary: true, domain: [],
+                                    description: "", source: "custom", tableRef: "custom", temporary: true, domain: [],
                                 } as FieldItem
                             });
 

--- a/src/views/ModelSelectionDialog.tsx
+++ b/src/views/ModelSelectionDialog.tsx
@@ -59,18 +59,6 @@ interface AppConfig {
     SHOW_KEYS_ENABLED: boolean;
 }
 
-export const GroupHeader = styled('div')(({ theme }) => ({
-    position: 'sticky',
-    padding: '8px 8px',
-    marginLeft: '-8px',
-    color: "rgba(0, 0, 0, 0.6)",
-    fontSize: "12px",
-}));
-
-export const GroupItems = styled('ul')({
-    padding: 0,
-});
-
 export const ModelSelectionButton: React.FC<{}> = ({ }) => {
 
     const dispatch = useDispatch();

--- a/src/views/ReactTable.tsx
+++ b/src/views/ReactTable.tsx
@@ -71,7 +71,7 @@ export const CustomReactTable: React.FC<CustomReactTableProps> = ({ rows, column
                                 return <TableCell
                                         key={column.id}
                                         align={column.align}
-                                        style={{
+                                        sx={{
                                             minWidth: column.minWidth, fontSize: 12, color: "#333",
                                             backgroundColor: backgroundColor,
                                             borderBottomColor, borderBottomWidth: '1px', borderBottomStyle: 'solid'

--- a/src/views/TableSelectionView.tsx
+++ b/src/views/TableSelectionView.tsx
@@ -177,7 +177,7 @@ export const TableSelectionDialog: React.FC<{ buttonElement: any }> = function T
             .then((response) => response.json())
             .then((result) => {
                 let tableChallenges : TableChallenges[] = result.map((info: any) => {
-                    let table = createTableFromFromObjectArray(info["name"], JSON.parse(info["snapshot"]))
+                    let table = createTableFromFromObjectArray(info["name"], JSON.parse(info["snapshot"]), true)
                     return {table: table, challenges: info["challenges"], name: info["name"]}
                 }).filter((t : TableChallenges | undefined) => t != undefined);
                 setDatasetPreviews(tableChallenges);
@@ -221,7 +221,7 @@ export const TableSelectionDialog: React.FC<{ buttonElement: any }> = function T
                                 return response.text()
                             })
                             .then((text) => {         
-                                let fullTable = createTableFromFromObjectArray(tableChallenges.table.id, JSON.parse(text));
+                                let fullTable = createTableFromFromObjectArray(tableChallenges.table.id, JSON.parse(text), true);
                                 if (fullTable) {
                                     dispatch(dfActions.loadTable(fullTable));
                                     dispatch(fetchFieldSemanticType(fullTable));
@@ -389,7 +389,7 @@ export const TableURLDialog: React.FC<TableURLDialogProps> = ({ buttonElement, d
             let table : undefined | DictTable = undefined;
             try {
                 let jsonContent = JSON.parse(content);
-                table = createTableFromFromObjectArray(tableName || 'dataset', jsonContent);
+                table = createTableFromFromObjectArray(tableName || 'dataset', jsonContent, true);
             } catch (error) {
                 table = createTableFromText(tableName || 'dataset', content);
             }
@@ -486,7 +486,7 @@ export const TableCopyDialogV2: React.FC<TableCopyDialogProps> = ({ buttonElemen
 
         try {
             let content = JSON.parse(tableStr);
-            table = createTableFromFromObjectArray(uniqueName, content);
+            table = createTableFromFromObjectArray(uniqueName, content, true);
         } catch (error) {
             table = createTableFromText(uniqueName, tableStr);
         }

--- a/src/views/ViewUtils.tsx
+++ b/src/views/ViewUtils.tsx
@@ -142,7 +142,7 @@ export const groupConceptItems = (conceptShelfItems: FieldItem[])  => {
         } else if (f.source == "custom") {
             group = "new fields"
         } else if (f.source == "derived") {
-            group = findBaseFields(f, conceptShelfItems)[0].tableRef || "custom concepts";
+            group = f.tableRef as string;
         }
         return {group, field: f}
     });

--- a/src/views/ViewUtils.tsx
+++ b/src/views/ViewUtils.tsx
@@ -133,16 +133,16 @@ export const findBaseFields = (field: FieldItem, conceptShelfItems: FieldItem[])
     }
 }
 
-export const groupConceptItems = (conceptShelfItems: FieldItem[])  => {
+export const groupConceptItems = (conceptShelfItems: FieldItem[], tables: DictTable[])  => {
     // group concepts based on which source table they belongs to
     return conceptShelfItems.map(f => {
         let group = ""
         if (f.source == "original") {
-            group = f.tableRef as string;
+            group = tables.find(t => t.id == f.tableRef)?.displayId || f.tableRef;
         } else if (f.source == "custom") {
             group = "new fields"
         } else if (f.source == "derived") {
-            group = f.tableRef as string;
+            group = tables.find(t => t.id == f.tableRef)?.displayId || f.tableRef;
         }
         return {group, field: f}
     });

--- a/src/views/VisualizationView.tsx
+++ b/src/views/VisualizationView.tsx
@@ -261,7 +261,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
 
     let [collapseEditor, setCollapseEditor] = useState<boolean>(false);
 
-    let scaleFactor = focusedChart.scaleFactor || 1;
+    const [localScaleFactor, setLocalScaleFactor] = useState<number>(1);
 
     useEffect(() => {
         setFocusUpdated(true);
@@ -321,7 +321,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                 if (comp) {
                     const { width, height } = comp.getBoundingClientRect();
                     // console.log(`main chart; width = ${width} height = ${height}`)
-                    comp?.setAttribute("style", `width: ${width * scaleFactor}px; height: ${height * scaleFactor}px;`);
+                    comp?.setAttribute("style", `width: ${width * localScaleFactor}px; height: ${height * localScaleFactor}px;`);
                 }
             }
 
@@ -330,7 +330,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                 if (comp) {
                     const { width, height } = comp.getBoundingClientRect();
                     // console.log(`main chart; width = ${width} height = ${height}`)
-                    comp?.setAttribute("style", `width: ${width * scaleFactor}px; height: ${height * scaleFactor}px;`);
+                    comp?.setAttribute("style", `width: ${width * localScaleFactor}px; height: ${height * localScaleFactor}px;`);
                 }
             }
 
@@ -557,6 +557,10 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
              </Box>
         ]
     } else {
+
+        let transformationIndicatorText = table.derive?.source ? 
+            `${table.derive.source.map(s => tables.find(t => t.id === s)?.displayId || s).join(", ")} → ${table.displayId || table.id}` : "";
+
         focusedComponent = [
             <Box key="chart-focused-element"  sx={{ margin: "auto", display: "flex", flexDirection: "column"}}>
                 <AnimateOnChange
@@ -569,17 +573,6 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                         <Collapse in={codeViewOpen}>
                             <Box sx={{minWidth: 440, maxWidth: 800, padding: "0px 8px", position: 'relative', margin: '8px auto'}}>
                                 <ButtonGroup sx={{position: 'absolute', right: 8, top: 1}}>
-                                    {/* <Tooltip title="view data derivation dialog" key="focused-view-chat-history-btn-tooltip">
-                                        <IconButton color="secondary" sx={{ textTransform: "none" }} 
-                                                onClick={() => { setChatDialogOpen(!chatDialogOpen) }}><QuestionAnswerIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Divider />
-                                    <Tooltip title="go to explanation view" key="view-code-expl-btn-tooltip">
-                                        <IconButton color="primary" sx={{ textTransform: "none" }} 
-                                                onClick={() => { setCodeViewOpen(false); setCodeExplViewOpen(true) }}><AssistantIcon />
-                                        </IconButton>
-                                    </Tooltip> */}
                                     <IconButton onClick={() => {setCodeViewOpen(false)}}  color='primary' aria-label="delete">
                                         <CloseIcon />
                                     </IconButton>
@@ -590,7 +583,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                                         border: "1px solid rgba(33, 33, 33, 0.1)"}}>
                                     <CardContent sx={{display: "flex", flexDirection: "column", flexGrow: 1, padding: '0', paddingBottom: '0px !important'}}>
                                         <Typography sx={{ fontSize: 14, margin: 1 }}  gutterBottom>
-                                            Data transformation code ({table.derive?.source} → {table.id})
+                                            Data transformation code ({transformationIndicatorText})
                                         </Typography>
                                         <Box sx={{display: 'flex', flexDirection: "row", alignItems: "center", flex: 'auto', padding: 1, background: '#f5f2f0'}}>
                                             <Box sx={{maxWidth: 800, width: 'fit-content',  display: 'flex',}}>
@@ -604,17 +597,6 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                         <Collapse in={codeExplViewOpen}>
                             <Box sx={{minWidth: 440, maxWidth: 800, padding: "0px 8px", position: 'relative', margin: '8px auto'}}>
                                 <ButtonGroup sx={{position: 'absolute', right: 8, top: 0}}>
-                                    {/* <Tooltip title="view data derivation dialog" key="view-chat-history-btn-tooltip">
-                                        <IconButton color="secondary" sx={{ textTransform: "none" }} 
-                                                onClick={() => { setChatDialogOpen(!chatDialogOpen) }}><QuestionAnswerIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <Divider />
-                                    <Tooltip title="go to code view" key="view-code-expl-btn-tooltip">
-                                        <IconButton color="primary" sx={{ textTransform: "none" }} 
-                                                onClick={() => { setCodeViewOpen(true); setCodeExplViewOpen(false) }}><TerminalIcon />
-                                        </IconButton>
-                                    </Tooltip> */}
                                     <IconButton onClick={() => {setCodeExplViewOpen(false)}}  color='primary' aria-label="delete">
                                         <CloseIcon />
                                     </IconButton>
@@ -624,7 +606,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
                                         border: "1px solid rgba(33, 33, 33, 0.1)"}}>
                                     <CardContent sx={{display: "flex", flexDirection: "column", flexGrow: 1, padding: '0', paddingBottom: '0px !important'}}>
                                         <Typography sx={{ fontSize: 14, margin: 1 }}  gutterBottom>
-                                            Data transformation explanation ({table.derive?.source} → {table.id})
+                                            Data transformation explanation ({transformationIndicatorText})
                                         </Typography>
                                         <Box sx={{display: 'flex', flexDirection: "row", alignItems: "center", flex: 'auto', padding: 1, background: '#f5f2f0'}}>
                                             <Box sx={{width: 'fit-content',  display: 'flex',}}>
@@ -672,19 +654,19 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
 
     let chartResizer = <Stack spacing={1} direction="row" sx={{ padding: '8px', width: 160, position: "absolute", zIndex: 10, color: 'darkgray' }} alignItems="center">
         <Tooltip title="zoom out">
-            <IconButton color="primary" size='small' disabled={scaleFactor <= scaleMin} onClick={() => {
-                dispatch(dfActions.updateChartScaleFactor({ chartId: focusedChart.id, scaleFactor: scaleFactor - 0.1 }))
+            <IconButton color="primary" size='small' disabled={localScaleFactor <= scaleMin} onClick={() => {
+                setLocalScaleFactor(prev => Math.max(scaleMin, prev - 0.1));
             }}>
                 <ZoomOutIcon fontSize="small" />
             </IconButton>
         </Tooltip>
         <Slider aria-label="chart-resize" defaultValue={1} step={0.1} min={scaleMin} max={scaleMax} 
-                value={scaleFactor} onChange={(event: Event, newValue: number | number[]) => {
-            dispatch(dfActions.updateChartScaleFactor({chartId: focusedChart.id, scaleFactor: newValue as number}))
+                value={localScaleFactor} onChange={(event: Event, newValue: number | number[]) => {
+            setLocalScaleFactor(newValue as number);
         }} />
         <Tooltip title="zoom in">
-            <IconButton color="primary" size='small' disabled={scaleFactor >= scaleMax} onClick={() => {
-                dispatch(dfActions.updateChartScaleFactor({ chartId: focusedChart.id, scaleFactor: scaleFactor + 0.1 }))
+            <IconButton color="primary" size='small' disabled={localScaleFactor >= scaleMax} onClick={() => {
+                setLocalScaleFactor(prev => Math.min(scaleMax, prev + 0.1));
             }}>
                 <ZoomInIcon fontSize="small" />
             </IconButton>

--- a/src/views/VisualizationView.tsx
+++ b/src/views/VisualizationView.tsx
@@ -229,9 +229,6 @@ const BaseChartCreationMenu: FC<{tableId: string; buttonElement: any}> = functio
     </>;
 }
 
-export const ChartCreationMenu = styled(BaseChartCreationMenu)({});
-
-
 export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
             handleUpdateCandidates: (chartId: string, tables: DictTable[]) => void,
     }> = function ChartEditorFC({ cachedCandidates, handleUpdateCandidates }) {
@@ -405,7 +402,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
         </IconButton>
     </Tooltip>
 
-    let createNewChartButton =  <ChartCreationMenu tableId={focusedChart.tableRef} buttonElement={
+    let createNewChartButton =  <BaseChartCreationMenu tableId={focusedChart.tableRef} buttonElement={
             <Tooltip title="create a new chart">
                 <AddchartIcon sx={{ fontSize: "3rem" }} />
             </Tooltip>} />

--- a/src/views/VisualizationView.tsx
+++ b/src/views/VisualizationView.tsx
@@ -454,7 +454,7 @@ export const ChartEditorFC: FC<{  cachedCandidates: DictTable[],
     let chartActionButtons = [
         <Box key="data-source" fontSize="small" sx={{ margin: "auto", display: "flex", flexDirection: "row"}}>
             <Typography component="span" sx={{}} fontSize="inherit">
-                data: {table.id}
+                data: {table.displayId || table.id}
             </Typography>
         </Box>,
         ...derivedTableItems,


### PR DESCRIPTION
With Data Anchor, we can anchor an intermediate data to isolate it's derivation context from it's predecessors. Tables created from the anchor will take the anchored table as direct input (not the original data).

This could be helpful for cleaning initial input data (so we always work with cleaned data afterwards), or when we want to focus our analysis into a subset of dataset. 

This makes analysis clean, but also makes it more efficient for LLM to work with, since it won't have the gigantic context attached to the anchored data.

We'll merge it after some more testing and playing. Made quite a bit of updates so it can be messy(?)

Here is a quick demo:


https://github.com/user-attachments/assets/ec5cb307-2504-4c1a-9e55-956525cff3bf

