### PR TITLE
feat: Add ExcelDataLoader for Data Formulator

### DIFF
--- a/py-src/data_formulator/data_loader/__init__.py
+++ b/py-src/data_formulator/data_loader/__init__.py
@@ -1,10 +1,12 @@
 from data_formulator.data_loader.external_data_loader import ExternalDataLoader
 from data_formulator.data_loader.mysql_data_loader import MySQLDataLoader
 from data_formulator.data_loader.kusto_data_loader import KustoDataLoader
+from data_formulator.data_loader.excel_data_loader import ExcelDataLoader # Added import
 
 DATA_LOADERS = {
     "mysql": MySQLDataLoader,
-    "kusto": KustoDataLoader
+    "kusto": KustoDataLoader,
+    "excel": ExcelDataLoader  # Added ExcelDataLoader
 }
 
-__all__ = ["ExternalDataLoader", "MySQLDataLoader", "KustoDataLoader", "DATA_LOADERS"]
+__all__ = ["ExternalDataLoader", "MySQLDataLoader", "KustoDataLoader", "ExcelDataLoader", "DATA_LOADERS"] # Added ExcelDataLoader to __all__

--- a/py-src/data_formulator/data_loader/excel_data_loader.py
+++ b/py-src/data_formulator/data_loader/excel_data_loader.py
@@ -1,0 +1,142 @@
+from .external_data_loader import ExternalDataLoader, sanitize_table_name
+from typing import Dict, Any, List
+import pandas as pd
+import duckdb # Will be provided by Data Formulator core
+import json # Make sure json is imported
+
+class ExcelDataLoader(ExternalDataLoader):
+    @staticmethod
+    def list_params() -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "file_path",
+                "type": "string",
+                "required": True,
+                "description": "Path to the Excel file (e.g., /path/to/your/file.xlsx)",
+            }
+        ]
+
+    def __init__(self, params: Dict[str, Any], duck_db_conn: duckdb.DuckDBPyConnection):
+        self.file_path = params.get("file_path")
+        if not self.file_path:
+            raise ValueError("Missing required parameter: file_path")
+        
+        self.duck_db_conn = duck_db_conn # Store the duckdb connection
+        
+        try:
+            # Make sure to install openpyxl: pip install openpyxl
+            self.excel_file = pd.ExcelFile(self.file_path, engine='openpyxl')
+        except FileNotFoundError:
+            # More specific error for user
+            raise ValueError(f"Excel file not found at path: {self.file_path}. Please ensure the path is correct and the file exists.")
+        except Exception as e:
+            # Catch other pandas/openpyxl exceptions, e.g., if the file is not a valid Excel file
+            raise ValueError(f"Error opening or parsing Excel file at {self.file_path}. Ensure it's a valid Excel file. Error: {e}")
+
+    def list_tables(self) -> List[Dict[str, Any]]:
+        sheet_details = []
+        if not self.excel_file:
+            raise ValueError("Excel file is not loaded. Cannot list sheets.")
+
+        sheet_names = self.excel_file.sheet_names
+        
+        for sheet_name in sheet_names:
+            try:
+                # Read a small sample to get header and types, limit rows to avoid loading large sheets
+                # Reading just the first row for columns, then first 5 for sample data
+                df_sample = pd.read_excel(self.excel_file, sheet_name=sheet_name, nrows=5)
+                
+                if df_sample.empty:
+                    column_names = []
+                    column_types = []
+                    sample_rows = []
+                else:
+                    column_names = df_sample.columns.tolist()
+                    column_types = [str(dtype) for dtype in df_sample.dtypes.tolist()] # Convert dtypes to string representations
+                    
+                    # Prepare sample data (list of lists)
+                    sample_rows = df_sample.head(5).values.tolist()
+
+                sheet_details.append({
+                    "table_name": sheet_name,
+                    "column_names": column_names,
+                    "column_types": column_types,
+                    "sample_data": sample_rows, # Sample data as a list of rows
+                })
+            except Exception as e:
+                # If a sheet cannot be read, we can skip it or log an error
+                # For now, let's print a warning and skip it
+                print(f"Warning: Could not read sheet '{sheet_name}'. Error: {e}")
+                sheet_details.append({
+                    "table_name": sheet_name,
+                    "column_names": [],
+                    "column_types": [],
+                    "sample_data": [],
+                    "error": f"Could not read sheet: {e}"
+                })
+        return sheet_details
+
+    def ingest_data(self, table_name: str, name_as: str = None, size: int = None): # Allow size to be None for full sheet
+        if not self.excel_file:
+            raise ValueError("Excel file is not loaded. Cannot ingest data.")
+
+        if table_name not in self.excel_file.sheet_names:
+            raise ValueError(f"Sheet '{table_name}' not found in the Excel file.")
+
+        final_table_name = sanitize_table_name(name_as if name_as else table_name)
+
+        try:
+            # Determine number of rows to read
+            nrows_to_read = size if size is not None and size > 0 else None
+
+            df = pd.read_excel(self.excel_file, sheet_name=table_name, nrows=nrows_to_read)
+            
+            if df.empty and table_name in self.excel_file.sheet_names:
+                # If df is empty but sheet exists, could be an empty sheet or only header
+                # Try to get columns if df is empty but sheet exists
+                # This case might be handled by how ingest_df_to_duckdb handles empty dataframes.
+                # For now, we pass it as is.
+                print(f"Warning: Sheet '{table_name}' is empty or contains only headers.")
+
+
+            # Use the inherited method to ingest the DataFrame into DuckDB
+            self.ingest_df_to_duckdb(df, final_table_name)
+            
+            print(f"Successfully ingested sheet '{table_name}' as table '{final_table_name}' into DuckDB.")
+            # Return information about the ingested table, like its name and number of rows
+            # This structure might need to align with what the frontend/caller expects.
+            # For now, returning a simple success message or dict.
+            return {
+                "status": "success",
+                "message": f"Sheet '{table_name}' ingested as '{final_table_name}'.",
+                "table_name": final_table_name,
+                "rows_ingested": len(df)
+            }
+
+        except Exception as e:
+            raise RuntimeError(f"Error ingesting sheet '{table_name}': {e}")
+
+    def view_query_sample(self, query: str) -> str: # query here will be the sheet name
+        if not self.excel_file:
+            raise ValueError("Excel file is not loaded. Cannot view sample.")
+
+        sheet_name = query # Assuming 'query' is the sheet name for Excel files
+        
+        if sheet_name not in self.excel_file.sheet_names:
+            # Check if it's a table name that might exist in DuckDB (e.g., after ingestion)
+            # However, this method is about previewing from the *source* (Excel)
+            # So, if the sheet_name isn't in the Excel file, it's an error for this method's intent.
+            raise ValueError(f"Sheet '{sheet_name}' not found in the Excel file.")
+
+        try:
+            df_sample = pd.read_excel(self.excel_file, sheet_name=sheet_name, nrows=5)
+            # Convert dataframe sample to JSON string
+            return df_sample.to_json(orient="records", indent=4)
+        except Exception as e:
+            # Handle cases where sheet might exist but can't be read, or other pandas errors
+            raise RuntimeError(f"Error reading sample from sheet '{sheet_name}': {e}")
+
+    def ingest_data_from_query(self, query: str, name_as: str):
+        # This method is not typically applicable to Excel files which are not queryable databases.
+        # The primary way to ingest data is by sheet name using ingest_data.
+        raise NotImplementedError("Ingesting data from a query is not supported for Excel files. Please use 'ingest_data' by sheet name.")

--- a/py-src/data_formulator/tests/test_excel_data_loader.py
+++ b/py-src/data_formulator/tests/test_excel_data_loader.py
@@ -1,0 +1,171 @@
+import unittest
+import pandas as pd
+import duckdb
+import os
+import json
+import tempfile
+from data_formulator.data_loader.excel_data_loader import ExcelDataLoader
+from data_formulator.data_loader.external_data_loader import sanitize_table_name
+import pandas.testing as pd_testing
+
+class TestExcelDataLoader(unittest.TestCase):
+    def setUp(self):
+        # Initialize DuckDB connection
+        self.db_conn = duckdb.connect(':memory:')
+
+        # Create sample data
+        self.sheet1_name = 'Sheet1_Data'
+        self.sheet1_data = pd.DataFrame({
+            'ID': [1, 2, 3],
+            'Name': ['Alice', 'Bob', 'Charlie'],
+            'Value': [100, 200, 300]
+        })
+
+        self.sheet2_name = 'Another_Sheet'
+        self.sheet2_data = pd.DataFrame({
+            'Category': ['X', 'Y', 'X', 'Z'],
+            'Data1': [10.1, 20.2, 30.3, 40.4],
+            'Data2': ['text1', 'text2', 'text3', 'text4']
+        })
+        
+        # Create a temporary Excel file
+        # delete=False is important because we need to close it before ExcelDataLoader can open it
+        # and then delete it manually in tearDown.
+        temp_file = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
+        self.excel_file_path = temp_file.name
+        temp_file.close() # Close the file handle so pandas can write to it
+
+        try:
+            with pd.ExcelWriter(self.excel_file_path, engine='openpyxl') as writer:
+                self.sheet1_data.to_excel(writer, sheet_name=self.sheet1_name, index=False)
+                self.sheet2_data.to_excel(writer, sheet_name=self.sheet2_name, index=False)
+        except Exception as e:
+            # If setup fails, try to clean up the temp file if it was created
+            if os.path.exists(self.excel_file_path):
+                os.remove(self.excel_file_path)
+            raise e
+
+
+    def tearDown(self):
+        # Close DuckDB connection
+        if hasattr(self, 'db_conn') and self.db_conn:
+            self.db_conn.close()
+        
+        # Delete the temporary Excel file
+        if hasattr(self, 'excel_file_path') and os.path.exists(self.excel_file_path):
+            os.remove(self.excel_file_path)
+
+    # Test cases will be added here
+    def test_list_params(self):
+        params = ExcelDataLoader.list_params()
+        self.assertEqual(len(params), 1)
+        param = params[0]
+        self.assertEqual(param["name"], "file_path")
+        self.assertEqual(param["type"], "string")
+        self.assertTrue(param["required"])
+        self.assertIn("Path to the Excel file", param["description"])
+
+    def test_init_success(self):
+        try:
+            loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+            self.assertIsNotNone(loader.excel_file) # Check if excel_file attribute is populated
+            self.assertEqual(loader.file_path, self.excel_file_path)
+        except Exception as e:
+            self.fail(f"ExcelDataLoader initialization failed: {e}")
+
+    def test_init_file_not_found(self):
+        with self.assertRaisesRegex(ValueError, "Excel file not found at path: non_existent_file.xlsx"):
+            ExcelDataLoader(params={"file_path": "non_existent_file.xlsx"}, duck_db_conn=self.db_conn)
+
+    def test_list_tables(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+        tables = loader.list_tables()
+
+        self.assertEqual(len(tables), 2) # Expecting two sheets
+
+        # Verify Sheet1_Data
+        sheet1_info = next((t for t in tables if t["table_name"] == self.sheet1_name), None)
+        self.assertIsNotNone(sheet1_info)
+        self.assertListEqual(sheet1_info["column_names"], self.sheet1_data.columns.tolist())
+        # Pandas dtypes are specific, for simplicity in test, we might just check if they are strings
+        self.assertEqual(len(sheet1_info["column_types"]), len(self.sheet1_data.columns))
+        self.assertEqual(len(sheet1_info["sample_data"]), 3) # 3 rows of sample data
+        self.assertListEqual(sheet1_info["sample_data"][0], self.sheet1_data.iloc[0].tolist())
+
+        # Verify Another_Sheet
+        sheet2_info = next((t for t in tables if t["table_name"] == self.sheet2_name), None)
+        self.assertIsNotNone(sheet2_info)
+        self.assertListEqual(sheet2_info["column_names"], self.sheet2_data.columns.tolist())
+        self.assertEqual(len(sheet2_info["column_types"]), len(self.sheet2_data.columns))
+        self.assertEqual(len(sheet2_info["sample_data"]), 4) # 4 rows of sample data
+        self.assertListEqual(sheet2_info["sample_data"][0], self.sheet2_data.iloc[0].tolist())
+
+    def test_ingest_data_success(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+
+        # Test ingesting Sheet1_Data with its original name
+        ingest_result1 = loader.ingest_data(table_name=self.sheet1_name)
+        expected_table_name1 = sanitize_table_name(self.sheet1_name)
+        
+        self.assertEqual(ingest_result1["status"], "success")
+        self.assertEqual(ingest_result1["table_name"], expected_table_name1)
+        self.assertEqual(ingest_result1["rows_ingested"], len(self.sheet1_data))
+
+        # Verify data in DuckDB for Sheet1_Data
+        duckdb_df1 = self.db_conn.execute(f"SELECT * FROM {expected_table_name1}").fetchdf()
+        # Convert all columns to object type before comparison to avoid dtype mismatches with read_excel
+        # This is a common strategy when dtypes are not strictly controlled or critical for the test's purpose.
+        # Alternatively, ensure precise dtype matching if that's a requirement.
+        pd_testing.assert_frame_equal(duckdb_df1.astype(object), self.sheet1_data.astype(object), check_dtype=False)
+
+
+        # Test ingesting Another_Sheet with a custom name using 'name_as'
+        custom_table_name = "CustomSheetName"
+        ingest_result2 = loader.ingest_data(table_name=self.sheet2_name, name_as=custom_table_name)
+        expected_table_name2 = sanitize_table_name(custom_table_name)
+
+        self.assertEqual(ingest_result2["status"], "success")
+        self.assertEqual(ingest_result2["table_name"], expected_table_name2)
+        self.assertEqual(ingest_result2["rows_ingested"], len(self.sheet2_data))
+
+        # Verify data in DuckDB for Another_Sheet (with custom name)
+        duckdb_df2 = self.db_conn.execute(f"SELECT * FROM {expected_table_name2}").fetchdf()
+        pd_testing.assert_frame_equal(duckdb_df2.astype(object), self.sheet2_data.astype(object), check_dtype=False)
+
+    def test_ingest_data_sheet_not_found(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+        with self.assertRaisesRegex(ValueError, "Sheet 'NonExistentSheet' not found in the Excel file."):
+            loader.ingest_data(table_name="NonExistentSheet")
+
+    def test_view_query_sample_success(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+        
+        # Test viewing sample for Sheet1_Data
+        sample_json_str = loader.view_query_sample(query=self.sheet1_name)
+        sample_data = json.loads(sample_json_str)
+
+        self.assertEqual(len(sample_data), len(self.sheet1_data)) # Should return all 3 rows as it's less than 5
+        # Verify the first row's content (adjusting for potential type differences from JSON conversion if necessary)
+        # For simplicity, comparing as read by pandas initially.
+        expected_first_row = self.sheet1_data.iloc[0].to_dict()
+        self.assertDictEqual(sample_data[0], expected_first_row)
+
+        # Test viewing sample for Another_Sheet (which has 4 rows, so all should be returned)
+        sample_json_str_2 = loader.view_query_sample(query=self.sheet2_name)
+        sample_data_2 = json.loads(sample_json_str_2)
+        self.assertEqual(len(sample_data_2), len(self.sheet2_data)) # All 4 rows
+        expected_first_row_2 = self.sheet2_data.iloc[0].to_dict()
+        self.assertDictEqual(sample_data_2[0], expected_first_row_2)
+
+    def test_view_query_sample_sheet_not_found(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+        with self.assertRaisesRegex(ValueError, "Sheet 'NonExistentSheet' not found in the Excel file."):
+            loader.view_query_sample(query="NonExistentSheet")
+
+    def test_ingest_data_from_query_not_implemented(self):
+        loader = ExcelDataLoader(params={"file_path": self.excel_file_path}, duck_db_conn=self.db_conn)
+        with self.assertRaises(NotImplementedError):
+            loader.ingest_data_from_query(query="SELECT * FROM SomeSheet", name_as="some_table")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 autopep8
 jupyter
 pandas
+openpyxl
 docker
 namedlist
 matplotlib


### PR DESCRIPTION
This commit introduces a new data loader for Microsoft's Data Formulator, enabling you to load data directly from Excel files (.xlsx).

Key changes include:

- Created `ExcelDataLoader` class in `py-src/data_formulator/data_loader/excel_data_loader.py`, inheriting from `ExternalDataLoader`.
- Implemented methods in `ExcelDataLoader`:
    - `list_params()`: Defines `file_path` as a required parameter.
    - `__init__()`: Initializes the loader with the Excel file path and DuckDB connection, using pandas and openpyxl to read the file.
    - `list_tables()`: Lists all sheets in the Excel file as available tables, providing sheet names, column details, and sample data.
    - `ingest_data()`: Loads data from a specified Excel sheet into a DuckDB table, using the inherited `ingest_df_to_duckdb` method. Supports custom table naming via `name_as`.
    - `view_query_sample()`: Returns a JSON sample of the first few rows of a specified sheet.
    - `ingest_data_from_query()`: Raises `NotImplementedError` as direct querying is not applicable to Excel files in this context.
- Registered `ExcelDataLoader` in `py-src/data_formulator/data_loader/__init__.py` to make it available to the application.
- Added `openpyxl` to `requirements.txt` as a necessary dependency for pandas to handle `.xlsx` files (`pandas` was already listed).
- Created comprehensive unit tests in `py-src/data_formulator/tests/test_excel_data_loader.py` covering various functionalities of `ExcelDataLoader`, including initialization, listing tables, data ingestion, sample viewing, and error handling scenarios. A temporary Excel file with multiple sheets is generated during test setup for thorough testing.

This new loader enhances Data Formulator's capability to work with diverse data sources, allowing you to easily integrate your existing Excel-based datasets for visualization and analysis.