### PR TITLE
Adds support for MySQL port configuration

### DIFF
--- a/py-src/data_formulator/data_loader/mysql_data_loader.py
+++ b/py-src/data_formulator/data_loader/mysql_data_loader.py
@@ -14,6 +14,7 @@ class MySQLDataLoader(ExternalDataLoader):
             {"name": "user", "type": "string", "required": True, "default": "root", "description": ""}, 
             {"name": "password", "type": "string", "required": False, "default": "", "description": "leave blank for no password"}, 
             {"name": "host", "type": "string", "required": True, "default": "localhost", "description": ""}, 
+            {"name": "port", "type": "int", "required": False, "default": 3306, "description": "MySQL server port (default 3306)"},
             {"name": "database", "type": "string", "required": True, "default": "mysql", "description": ""}
         ]
         return params_list
@@ -25,11 +26,11 @@ MySQL Connection Instructions:
 
 1. Local MySQL Setup:
    - Ensure MySQL server is running on your machine
-   - Default connection: host='localhost', user='root'
+   - Default connection: host='localhost', user='root', port=3306
    - If you haven't set a root password, leave password field empty
 
 2. Remote MySQL Connection:
-   - Obtain host address, username, and password from your database administrator
+   - Obtain host address, port, username, and password from your database administrator
    - Ensure the MySQL server allows remote connections
    - Check that your IP is whitelisted in MySQL's user permissions
 
@@ -37,11 +38,12 @@ MySQL Connection Instructions:
    - user: Your MySQL username (default: 'root')
    - password: Your MySQL password (leave empty if no password set)
    - host: MySQL server address (default: 'localhost')
+   - port: MySQL server port (default: 3306)
    - database: Target database name to connect to
 
 4. Troubleshooting:
    - Verify MySQL service is running: `brew services list` (macOS) or `sudo systemctl status mysql` (Linux)
-   - Test connection: `mysql -u [username] -p -h [host] [database]`
+   - Test connection: `mysql -u [username] -p -h [host] -P [port] [database]`
 """
 
     def __init__(self, params: Dict[str, Any], duck_db_conn: duckdb.DuckDBPyConnection):
@@ -54,7 +56,7 @@ MySQL Connection Instructions:
         
         attatch_string = ""
         for key, value in self.params.items():
-            if value:
+            if value is not None and value != "":
                 attatch_string += f"{key}={value} "
 
         # Detach existing mysqldb connection if it exists


### PR DESCRIPTION
Introduces a new optional parameter for specifying the MySQL server port, with a default value of 3306.

Updates connection instructions to include port information for both local and remote connections.

Enhances clarity in troubleshooting steps for testing connections with the specified port.