### PR TITLE
Apply JOOLIO branding and color palette

### DIFF
--- a/embed/dynamic.html
+++ b/embed/dynamic.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Data Formulator embedded dynamically</title>
+    <title>JOOLIO embedded dynamically</title>
 </head>
 
 <body>

--- a/embed/index.html
+++ b/embed/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Data Formulator embedded</title>
+    <title>JOOLIO embedded</title>
 </head>
 <body>
     <div id="root"></div>

--- a/embed/postMessageTest.html
+++ b/embed/postMessageTest.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Data Formulator embedded iframe</title>
+    <title>JOOLIO embedded iframe</title>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#1DB954" />
     <meta
-      name="Data Formulator"
+      name="JOOLIO"
       content="Concept-driven Visualization Authoring"
     />
     
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Data Formulator</title>
+    <title>JOOLIO</title>
   </head>
   <body>
     <noscript>Run this app with javascript</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Data Formulator",
-  "name": "Data Formulator",
+  "short_name": "JOOLIO",
+  "name": "JOOLIO",
   "icons": [
     {
       "src": "data-formulator-logo-128.png",
@@ -10,6 +10,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#1DB954",
+  "background_color": "#f8f9fa"
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -213,7 +213,7 @@ export const ExportStateButton: React.FC<{}> = ({ }) => {
 
 //type AppProps = ConnectedProps<typeof connector>;
 
-export const toolName = "Data Formulator"
+export const toolName = "JOOLIO"
 
 export interface AppFCProps {
 }
@@ -666,22 +666,26 @@ export const AppFC: FC<AppFCProps> = function AppFC(appProps) {
         //         main: '#bf5600', // New accessible color, original (#ed6c02) has insufficient color contrast of 3.11
         //     },
         // },
-       // Microsoft Fluent UI palette (alternative option)
+       // JOOLIO Brand Palette
         palette: {
             primary: {
-                main: '#0078d4'      // Fluent UI themePrimary (Microsoft Blue)
+                main: '#1DB954'      // JOOLIO Primary (Green)
             },
             secondary: {
-                main: '#8764b8'      // Fluent UI purple
+                main: '#2d2d2d'      // JOOLIO Gray
             },
             derived: {
-                main: '#ffb900',     // Fluent UI yellow/gold
+                main: '#f59e0b',     // JOOLIO Accent (Amber/Orange)
             },
             custom: {
-                main: '#d83b01',     // Fluent UI orange (Office orange)
+                main: '#f59e0b',     // JOOLIO Accent (Amber/Orange)
             },
             warning: {
-                main: '#a4262c',     // Fluent UI red (accessible)
+                main: '#dc2626',     // Red for warnings
+            },
+            background: {
+                default: '#f8f9fa', // JOOLIO Light
+                paper: '#ffffff',
             },
         },
     });

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -5,7 +5,7 @@ h2.view-title {
     margin: 0;
     line-height: 1.75;
     display: inline-block;
-    color: #717171;
+    color: #2d2d2d;
     //font-weight: 600;
     //text-transform: uppercase;
     font-size: 14px;
@@ -67,7 +67,7 @@ h2.view-title {
 .GroupHeader {
     position: sticky;
     padding: 4px 8px;
-    color: rgba(0, 0, 0, 0.6);
+    color: #2d2d2d;
     font-size: 12px;
 }
 
@@ -84,22 +84,23 @@ h2.view-title {
     }
 
     &::-webkit-scrollbar-track {
-        background: #f1f1f1;
+        background: #f8f9fa;
         border-radius: 4px;
     }
 
     &::-webkit-scrollbar-thumb {
-        background: #c1c1c1;
+        background: #2d2d2d;
         border-radius: 4px;
         transition: background-color 0.3s ease;
+        opacity: 0.5;
     }
 
     &::-webkit-scrollbar-thumb:hover {
-        background: #a8a8a8;
+        background: #1a1a1a;
     }
 
     &::-webkit-scrollbar-corner {
-        background: #f1f1f1;
+        background: #f8f9fa;
     }
 
     // Firefox

--- a/src/scss/DataView.scss
+++ b/src/scss/DataView.scss
@@ -24,7 +24,7 @@
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
-    background-color: #fafafa;
+    background-color: #f8f9fa;
 }
 
 .table-header-icon {
@@ -32,17 +32,17 @@
     margin-top: 4px;
     display: inline-block;
     font-size: 18px;
-    color: #717171;
+    color: #2d2d2d;
 }
 
 .table-container-small {
 
     .derived-column-header {
-        background-color: rgba(255, 215, 0, 0.1);
+        background-color: rgba(245, 158, 11, 0.1);
     }
 
     .highlighted-column-header {
-        background-color:rgba(88, 24, 69, 0.05);
+        background-color: rgba(29, 185, 84, 0.08);
     }
 
     .data-view-header-label {
@@ -92,21 +92,21 @@ span.bold {
 
     &.original {
         .data-view-header-container {
-            border-bottom: 2px solid #0288d1;
+            border-bottom: 2px solid #1DB954;
         }
     }
 
     &.derived {
         .data-view-header-container {
-            background-color: #fffef1;
-            border-bottom: 2px solid #ffd700;
+            background-color: rgba(245, 158, 11, 0.05);
+            border-bottom: 2px solid #f59e0b;
         }
     }
 
     &.custom {
         .data-view-header-container {
-            background-color: #fff9f8;
-            border-bottom: 2px solid #ffb395;
+            background-color: rgba(245, 158, 11, 0.03);
+            border-bottom: 2px solid #f59e0b;
         }
     }
 
@@ -143,7 +143,7 @@ span.bold {
                 -webkit-box-orient: vertical;
                 max-height: 36px;
                 flex-shrink: 1;
-                color: #333;
+                color: #1a1a1a;
             }
         }
     }


### PR DESCRIPTION
- Update MUI theme with JOOLIO colors (Primary: #1DB954, Dark: #1a1a1a, Gray: #2d2d2d, Light: #f8f9fa, Accent: #f59e0b)
- Change app name from "Data Formulator" to "JOOLIO"
- Update SCSS files with new color scheme
- Update manifest.json with JOOLIO branding and theme colors
- Update HTML titles and meta tags across all pages