### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/py-src/data_formulator/agent_routes.py
+++ b/py-src/data_formulator/agent_routes.py
@@ -90,7 +90,7 @@ def check_available_models():
     results = []
     
     # Define configurations for different providers
-    providers = ['openai', 'azure', 'anthropic', 'gemini', 'ollama']
+    providers = ['openai', 'azure', 'anthropic', 'gemini', 'ollama', 'novita']
 
     for provider in providers:
         # Skip if provider is not enabled

--- a/py-src/data_formulator/agents/client_utils.py
+++ b/py-src/data_formulator/agents/client_utils.py
@@ -47,6 +47,10 @@ class Client(object):
                 self.model = model
             else:
                 self.model = f"ollama/{model}"
+        elif self.endpoint == "novita":
+            # Novita AI - OpenAI-compatible endpoint
+            self.params["api_base"] = api_base if api_base else "https://api.novita.ai/openai"
+
 
     @classmethod
     def from_config(cls, model_config: dict[str, str]):
@@ -79,7 +83,7 @@ class Client(object):
         """
         # Configure LiteLLM 
 
-        if self.endpoint == "openai":
+        if self.endpoint == "openai" or self.endpoint == "novita":
             client = openai.OpenAI(
                 base_url=self.params.get("api_base", None),
                 api_key=self.params.get("api_key", ""),
@@ -116,7 +120,7 @@ class Client(object):
         """
         Returns a response using OpenAI's Response API approach.
         """
-        if self.endpoint == "openai":
+        if self.endpoint == "openai" or self.endpoint == "novita":
             client = openai.OpenAI(
                 base_url=self.params.get("api_base", None),
                 api_key=self.params.get("api_key", ""),

--- a/src/views/ModelSelectionDialog.tsx
+++ b/src/views/ModelSelectionDialog.tsx
@@ -91,7 +91,8 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
         'azure': [],
         'anthropic': [],
         'gemini': [],
-        'ollama': []
+        'ollama': [],
+        'novita': []
     });
     const serverConfig = useSelector((state: DataFormulatorState) => state.serverConfig);
 
@@ -123,7 +124,8 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                     'azure': [],
                     'anthropic': [],
                     'gemini': [],
-                    'ollama': []
+                    'ollama': [],
+                    'novita': []
                 };
                 
                 data.forEach((modelConfig: any) => {
@@ -197,7 +199,7 @@ export const ModelSelectionButton: React.FC<{}> = ({ }) => {
                         setNewApiVersion("2024-02-15");
                     }
                 }}
-                options={['openai', 'azure', 'ollama', 'anthropic', 'gemini']}
+                options={['openai', 'azure', 'ollama', 'anthropic', 'gemini', 'novita']}
                 renderOption={(props, option) => (
                     <Typography {...props} onClick={() => setNewEndpoint(option)} sx={{fontSize: "0.875rem"}}>
                         {option}


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider. Novita offers an OpenAI-compatible API with competitive pricing and a wide selection of open-source models.

### Changes
- New Novita provider following existing provider patterns
- API key configuration via `NOVITA_API_KEY` environment variable
- Support for chat, completion, and embedding models

### Configuration
```
NOVITA_API_KEY=your_key_here
```

**Endpoint**: `https://api.novita.ai/openai`