### PR TITLE
fix(agent_routes): change model test error log level from warning to …

### DIFF
--- a/py-src/data_formulator/agent_routes.py
+++ b/py-src/data_formulator/agent_routes.py
@@ -234,7 +234,7 @@ def test_model():
                     "message": ""
                 }
         except Exception as e:
-            logger.warning(f"Error testing model {content['model'].get('id', '')}: {e}")
+            logger.exception(f"Error testing model {content['model'].get('id', '')}")
             is_global = content['model'].get('is_global', False)
             result = {
                 "model": content['model'],


### PR DESCRIPTION
…exception

 Use logger.exception instead of logger.warning to record complete error stack trace for easier debugging