### PR TITLE
refactor(data loading): remove rowLimit related code

### DIFF
--- a/py-src/data_formulator/agents/agent_data_loading_chat.py
+++ b/py-src/data_formulator/agents/agent_data_loading_chat.py
@@ -72,7 +72,7 @@ Rules:
 - execute_python auto-saves ALL DataFrames created in code.
 - Use Workflow 4 when the user describes an analysis goal and you need to find relevant data from connected sources.
 - In propose_load_plan, always pass source_id and table_key exactly from search_data_candidates/read_candidate_metadata.
-- Set row_limit when loading connected sources; the system will apply the user's configured limit automatically.
+- Do NOT set row_limit in propose_load_plan; the system applies the user's configured global limit automatically.
 
 Filter rules for propose_load_plan:
 - You MUST call read_candidate_metadata BEFORE proposing filters. Do NOT guess column names or values.
@@ -291,7 +291,6 @@ TOOLS = [
                                 },
                                 "sort_by": {"type": "string"},
                                 "sort_order": {"type": "string", "enum": ["asc", "desc"]},
-                                "row_limit": {"type": "integer"},
                             },
                             "required": ["source_id", "table_key", "display_name"],
                         },
@@ -964,8 +963,7 @@ class DataLoadingAgent:
         result["source_table"] = str(import_id)
         result["source_table_name"] = str(source_name)
         result["filters"] = self._normalize_load_plan_filters(result.get("filters"))
-        if not result.get("row_limit"):
-            result["row_limit"] = self.row_limit
+        result.pop("row_limit", None)
         return result
 
     def _lookup_catalog_entry(self, source_id, table_key):

--- a/src/components/ComponentType.tsx
+++ b/src/components/ComponentType.tsx
@@ -190,7 +190,6 @@ export interface LoadPlanCandidate {
     filters?: Array<{ column: string; operator: string; value?: any }>;
     sortBy?: string;
     sortOrder?: 'asc' | 'desc';
-    rowLimit?: number;
     selected?: boolean;
 }
 

--- a/src/components/LoadPlanCard.tsx
+++ b/src/components/LoadPlanCard.tsx
@@ -207,13 +207,6 @@ export const LoadPlanCard: React.FC<LoadPlanCardProps> = ({ plan, onConfirm, con
                                     sx={{ height: 18, fontSize: 10, '& .MuiChip-label': { px: 0.75 } }}
                                 />
                             )}
-                            {c.rowLimit && (
-                                <Chip
-                                    label={`${t('dataLoading.loadPlan.rowLimit')}: ${c.rowLimit.toLocaleString()}`}
-                                    size="small" variant="outlined"
-                                    sx={{ height: 18, fontSize: 10, '& .MuiChip-label': { px: 0.75 } }}
-                                />
-                            )}
                     </Box>
                     <Collapse in={!!preview?.expanded}>
                         <Box sx={{ pl: confirmed ? 0 : 3.5, mt: 0.75 }}>

--- a/src/views/DataLoadingChat.tsx
+++ b/src/views/DataLoadingChat.tsx
@@ -832,7 +832,6 @@ export const DataLoadingChat: React.FC = () => {
                                 filters: c.filters,
                                 sortBy: c.sort_by,
                                 sortOrder: c.sort_order,
-                                rowLimit: c.row_limit,
                                 selected: true,
                             })),
                             reasoning: action.reasoning,

--- a/tests/backend/agents/test_data_loading_discovery_tools.py
+++ b/tests/backend/agents/test_data_loading_discovery_tools.py
@@ -100,7 +100,6 @@ class TestProposeLoadPlan:
                     "table_key": "public.orders",
                     "display_name": "orders",
                     "source_table": "public.orders",
-                    "row_limit": 50000,
                 },
                 {
                     "source_id": "pg_prod",
@@ -118,7 +117,7 @@ class TestProposeLoadPlan:
         assert action["type"] == "load_plan"
         assert len(action["candidates"]) == 2
         assert action["candidates"][0]["source_id"] == "pg_prod"
-        assert action["candidates"][0]["row_limit"] == 50000
+        assert "row_limit" not in action["candidates"][0]
         assert action["reasoning"] == "Orders for last quarter + customer dimension"
 
     def test_empty_candidates_returns_empty_action(self) -> None:
@@ -164,7 +163,7 @@ class TestProposeLoadPlan:
         assert candidate["source_table"] == "136"
         assert candidate["source_table_name"] == "product_periodic_sales_trend"
         assert candidate["filters"] == [{"column": "brand", "operator": "EQ", "value": "Pantum"}]
-        assert candidate["row_limit"] == 2_000_000
+        assert "row_limit" not in candidate
 
 
 class TestNormalizeLoadPlanFilters:


### PR DESCRIPTION
Global row limit is now handled automatically by the system, so remove all rowLimit related logic from frontend, backend, and test code