### PR TITLE
Dev

### DIFF
--- a/py-src/data_formulator/data_connector.py
+++ b/py-src/data_formulator/data_connector.py
@@ -1241,6 +1241,7 @@ def list_connectors():
             "source": "admin" if is_admin else "user",
             "deletable": not is_admin,
             "source_type": connector._loader_class.__name__,
+            "type_name": connector._loader_class.DISPLAY_NAME or connector._icon,
             "display_name": connector._display_name,
             "icon": connector._icon,
             "connected": connected,
@@ -1442,6 +1443,38 @@ def _remove_user_connector(identity: str, connector_id: str) -> None:
             logger.info("Removed connector spec '%s'", connector_id)
     except Exception as e:
         logger.warning("Failed to remove connector spec '%s': %s", connector_id, e)
+
+
+def _update_user_connector_display_name(identity: str, connector_id: str, display_name: str) -> None:
+    jail = _connectors_jail(identity, mkdir=False)
+    filename = f"{_safe_source_filename(connector_id)}.json"
+    path = jail.resolve(filename)
+    if not path.exists():
+        raise AppError(ErrorCode.CONNECTOR_ERROR, f"Connector config not found: {connector_id}")
+    with open(path, "r", encoding="utf-8") as f:
+        entry = _json.load(f)
+    entry["display_name"] = display_name
+    with open(path, "w", encoding="utf-8") as f:
+        _json.dump(entry, f, ensure_ascii=False, indent=2)
+
+
+@connectors_bp.route("/api/connectors/<path:connector_id>", methods=["PATCH"])
+def update_connector(connector_id: str):
+    """Rename a user connector without changing its stable source ID."""
+    if connector_id in _ADMIN_CONNECTOR_IDS:
+        raise AppError(ErrorCode.ACCESS_DENIED, "Admin connectors cannot be renamed")
+
+    display_name = str((request.get_json() or {}).get("display_name", "")).strip()
+    if not display_name:
+        raise AppError(ErrorCode.INVALID_REQUEST, "display_name is required")
+    if len(display_name) > 120:
+        raise AppError(ErrorCode.VALIDATION_ERROR, "display_name must be 120 characters or fewer")
+
+    _registry_key, connector = _resolve_connector_with_key({"connector_id": connector_id})
+    identity = DataConnector._get_identity()
+    _update_user_connector_display_name(identity, connector_id, display_name)
+    connector._display_name = display_name
+    return json_ok({"id": connector_id, "display_name": display_name})
 
 
 @connectors_bp.route("/api/connectors/<path:connector_id>", methods=["DELETE"])

--- a/py-src/data_formulator/data_connector.py
+++ b/py-src/data_formulator/data_connector.py
@@ -1468,14 +1468,11 @@ def _update_user_connector_display_name(identity: str, connector_id: str, displa
     connector_id = _validate_connector_id_for_fs(connector_id)
     jail = _connectors_jail(identity, mkdir=False)
     filename = f"{_safe_source_filename(connector_id)}.json"
-    path = jail.resolve(filename)
-    if not path.exists():
+    if not jail.exists(filename):
         raise AppError(ErrorCode.CONNECTOR_ERROR, f"Connector config not found: {connector_id}")
-    with open(path, "r", encoding="utf-8") as f:
-        entry = _json.load(f)
+    entry = _json.loads(jail.read_text(filename))
     entry["display_name"] = display_name
-    with open(path, "w", encoding="utf-8") as f:
-        _json.dump(entry, f, ensure_ascii=False, indent=2)
+    jail.write_text(filename, _json.dumps(entry, ensure_ascii=False, indent=2))
 
 
 @connectors_bp.route("/api/connectors/<path:connector_id>", methods=["PATCH"])
@@ -1493,7 +1490,7 @@ def update_connector(connector_id: str):
 
     _registry_key, connector = _resolve_connector_with_key({"connector_id": connector_id})
     identity = DataConnector._get_identity()
-    _update_user_connector_display_name(identity, connector_id, display_name)
+    _update_user_connector_display_name(identity, connector._source_id, display_name)
     connector._display_name = display_name
     return json_ok({"id": connector_id, "display_name": display_name})
 

--- a/py-src/data_formulator/data_connector.py
+++ b/py-src/data_formulator/data_connector.py
@@ -23,6 +23,7 @@ import dataclasses
 import inspect
 import json as _json
 import logging
+import re
 import threading
 import time
 from pathlib import Path
@@ -1403,6 +1404,24 @@ def _connectors_jail(identity: str, *, mkdir: bool = True) -> ConfinedDir:
     return ConfinedDir(_connectors_dir(identity), mkdir=mkdir)
 
 
+_CONNECTOR_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,120}$")
+
+
+def _validate_connector_id_for_fs(connector_id: str) -> str:
+    """Validate connector id before any filesystem-derived usage.
+
+    Allows stable connector IDs used by this app (alnum plus ``_.:-``),
+    rejects separators/whitespace and other special characters.
+    """
+    value = str(connector_id).strip()
+    if not _CONNECTOR_ID_RE.fullmatch(value):
+        raise AppError(
+            ErrorCode.VALIDATION_ERROR,
+            "Invalid connector_id format",
+        )
+    return value
+
+
 def _safe_source_filename(source_id: str) -> str:
     """Sanitise a source_id into a safe, collision-resistant filename component.
 
@@ -1446,6 +1465,7 @@ def _remove_user_connector(identity: str, connector_id: str) -> None:
 
 
 def _update_user_connector_display_name(identity: str, connector_id: str, display_name: str) -> None:
+    connector_id = _validate_connector_id_for_fs(connector_id)
     jail = _connectors_jail(identity, mkdir=False)
     filename = f"{_safe_source_filename(connector_id)}.json"
     path = jail.resolve(filename)
@@ -1463,6 +1483,7 @@ def update_connector(connector_id: str):
     """Rename a user connector without changing its stable source ID."""
     if connector_id in _ADMIN_CONNECTOR_IDS:
         raise AppError(ErrorCode.ACCESS_DENIED, "Admin connectors cannot be renamed")
+    connector_id = _validate_connector_id_for_fs(connector_id)
 
     display_name = str((request.get_json() or {}).get("display_name", "")).strip()
     if not display_name:

--- a/py-src/data_formulator/data_loader/athena_data_loader.py
+++ b/py-src/data_formulator/data_loader/athena_data_loader.py
@@ -68,10 +68,10 @@ class AthenaDataLoader(ExternalDataLoader):
             {"name": "aws_secret_access_key", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "AWS secret access key (not required if using aws_profile)"},
             {"name": "aws_session_token", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "AWS session token (required for temporary credentials)"},
             {"name": "region_name", "type": "string", "required": True, "default": "us-east-1", "tier": "connection", "description": "AWS region name"},
-            {"name": "workgroup", "type": "string", "required": False, "default": "primary", "tier": "connection", "description": "Athena workgroup name (output location is fetched from workgroup configuration)"},
-            {"name": "output_location", "type": "string", "required": False, "default": "", "tier": "connection", "description": "S3 output location for query results (e.g., s3://bucket/path/). If empty, uses workgroup configuration."},
+            {"name": "workgroup", "type": "string", "required": False, "default": "primary", "tier": "connection", "advanced": True, "description": "Athena workgroup name (output location is fetched from workgroup configuration)"},
+            {"name": "output_location", "type": "string", "required": False, "default": "", "tier": "connection", "advanced": True, "description": "S3 output location for query results (e.g., s3://bucket/path/). If empty, uses workgroup configuration."},
             {"name": "database", "type": "string", "required": False, "default": "", "tier": "filter", "description": "Default database/catalog to use for queries"},
-            {"name": "query_timeout", "type": "number", "required": False, "default": 300, "tier": "connection", "description": "Query execution timeout in seconds (default: 300 = 5 minutes)"}
+            {"name": "query_timeout", "type": "number", "required": False, "default": 300, "tier": "connection", "advanced": True, "description": "Query execution timeout in seconds (default: 300 = 5 minutes)"}
         ]
         return params_list
 

--- a/py-src/data_formulator/data_loader/azure_blob_data_loader.py
+++ b/py-src/data_formulator/data_loader/azure_blob_data_loader.py
@@ -28,7 +28,7 @@ class AzureBlobDataLoader(ExternalDataLoader):
             {"name": "credential_chain", "type": "string", "required": False, "default": "cli;managed_identity;env", "tier": "auth", "description": "Ordered list of Azure credential providers (cli;managed_identity;env)"},
             {"name": "account_key", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "Azure storage account key"},
             {"name": "sas_token", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "Azure SAS token"},
-            {"name": "endpoint", "type": "string", "required": False, "default": "blob.core.windows.net", "tier": "connection", "description": "Azure endpoint override"}
+            {"name": "endpoint", "type": "string", "required": False, "default": "blob.core.windows.net", "tier": "connection", "advanced": True, "description": "Azure endpoint override"}
         ]
         return params_list
     

--- a/py-src/data_formulator/data_loader/bigquery_data_loader.py
+++ b/py-src/data_formulator/data_loader/bigquery_data_loader.py
@@ -23,7 +23,7 @@ class BigQueryDataLoader(ExternalDataLoader):
             {"name": "project_id", "type": "text", "required": True, "tier": "connection", "description": "Google Cloud Project ID", "default": ""},
             {"name": "dataset_id", "type": "text", "required": False, "tier": "filter", "description": "Dataset ID(s) - leave empty for all, or specify one (e.g., 'billing') or multiple separated by commas (e.g., 'billing,enterprise_collected,ga_api')", "default": ""},
             {"name": "credentials_path", "type": "text", "required": False, "tier": "auth", "description": "Path to service account JSON file (optional)", "default": ""},
-            {"name": "location", "type": "text", "required": False, "tier": "connection", "description": "BigQuery location (default: US)", "default": "US"}
+            {"name": "location", "type": "text", "required": False, "tier": "connection", "advanced": True, "description": "BigQuery location (default: US)", "default": "US"}
         ]
 
     @staticmethod

--- a/py-src/data_formulator/data_loader/local_folder_data_loader.py
+++ b/py-src/data_formulator/data_loader/local_folder_data_loader.py
@@ -54,6 +54,7 @@ class LocalFolderDataLoader(ExternalDataLoader):
                 "required": False,
                 "default": "true",
                 "tier": "connection",
+                "advanced": True,
                 "description": "Include files in subdirectories",
             },
             {
@@ -62,6 +63,7 @@ class LocalFolderDataLoader(ExternalDataLoader):
                 "required": False,
                 "default": "",
                 "tier": "connection",
+                "advanced": True,
                 "description": "Glob pattern to filter files (e.g. '*.csv')",
             },
         ]

--- a/py-src/data_formulator/data_loader/mongodb_data_loader.py
+++ b/py-src/data_formulator/data_loader/mongodb_data_loader.py
@@ -23,7 +23,7 @@ class MongoDBDataLoader(ExternalDataLoader):
     def list_params() -> list[dict[str, Any]]:
         params_list = [
             {"name": "host", "type": "string", "required": True, "default": "localhost", "tier": "connection", "description": "server address"}, 
-            {"name": "port", "type": "int", "required": False, "default": 27017, "tier": "connection", "description": "server port"},
+            {"name": "port", "type": "int", "required": False, "default": 27017, "tier": "connection", "advanced": True, "description": "server port"},
             {"name": "username", "type": "string", "required": False, "default": "", "tier": "auth", "description": "leave blank if no auth"},
             {"name": "password", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "leave blank if no auth"},
             {"name": "database", "type": "string", "required": True, "default": "", "tier": "connection", "description": "database name"},

--- a/py-src/data_formulator/data_loader/mssql_data_loader.py
+++ b/py-src/data_formulator/data_loader/mssql_data_loader.py
@@ -58,6 +58,7 @@ class MSSQLDataLoader(ExternalDataLoader):
                 "required": False,
                 "default": "1433",
                 "tier": "connection",
+                "advanced": True,
                 "description": "SQL Server port (default: 1433)",
             },
             {

--- a/py-src/data_formulator/data_loader/mysql_data_loader.py
+++ b/py-src/data_formulator/data_loader/mysql_data_loader.py
@@ -31,7 +31,7 @@ class MySQLDataLoader(ExternalDataLoader):
             {"name": "user", "type": "string", "required": True, "default": "root", "tier": "auth", "description": "MySQL username"}, 
             {"name": "password", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "leave blank for no password"}, 
             {"name": "host", "type": "string", "required": True, "default": "localhost", "tier": "connection", "description": "server address"}, 
-            {"name": "port", "type": "int", "required": False, "default": 3306, "tier": "connection", "description": "server port"},
+            {"name": "port", "type": "int", "required": False, "default": 3306, "tier": "connection", "advanced": True, "description": "server port"},
             {"name": "database", "type": "string", "required": False, "default": "", "tier": "filter", "description": "Database name (leave empty to browse all databases)"}
         ]
         return params_list

--- a/py-src/data_formulator/data_loader/postgresql_data_loader.py
+++ b/py-src/data_formulator/data_loader/postgresql_data_loader.py
@@ -35,7 +35,7 @@ class PostgreSQLDataLoader(ExternalDataLoader):
             {"name": "user", "type": "string", "required": True, "default": "postgres", "tier": "auth", "description": "PostgreSQL username"}, 
             {"name": "password", "type": "string", "required": False, "default": "", "sensitive": True, "tier": "auth", "description": "leave blank for no password"}, 
             {"name": "host", "type": "string", "required": True, "default": "localhost", "tier": "connection", "description": "PostgreSQL host"}, 
-            {"name": "port", "type": "string", "required": False, "default": "5432", "tier": "connection", "description": "PostgreSQL port"},
+            {"name": "port", "type": "string", "required": False, "default": "5432", "tier": "connection", "advanced": True, "description": "PostgreSQL port"},
             {"name": "database", "type": "string", "required": False, "default": "", "tier": "filter", "description": "Database name (leave empty to browse all databases)"}
         ]
         return params_list

--- a/py-src/data_formulator/datalake/naming.py
+++ b/py-src/data_formulator/datalake/naming.py
@@ -13,6 +13,11 @@ For **data-file** sanitisation see :func:`datalake.parquet_utils.safe_data_filen
 
 from __future__ import annotations
 
+import re
+
+
+_SAFE_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
 
 def safe_source_id(source_id: str) -> str:
     """Sanitise a ``source_id`` into a filesystem-safe, collision-resistant string.
@@ -24,6 +29,7 @@ def safe_source_id(source_id: str) -> str:
     * ``/`` and ``\\`` → ``_``  (path separators)
     * ``:``            → ``--`` (Windows-unsafe, and preserves uniqueness so that
       ``mysql:prod`` and ``mysql_prod`` map to different filenames)
+    * final value must match ``[A-Za-z0-9._-]+`` and not be ``.`` or ``..``
 
     Examples::
 
@@ -34,7 +40,14 @@ def safe_source_id(source_id: str) -> str:
         >>> safe_source_id("a:b/c\\\\d")
         'a--b_c_d'
     """
-    return source_id.replace("/", "_").replace("\\", "_").replace(":", "--")
+    sanitized = source_id.replace("/", "_").replace("\\", "_").replace(":", "--")
+    if not sanitized or sanitized in {".", ".."}:
+        raise ValueError("source_id must not be empty or relative-dot segments")
+    if len(sanitized) > 255:
+        raise ValueError("source_id is too long")
+    if not _SAFE_SOURCE_ID_RE.fullmatch(sanitized):
+        raise ValueError("source_id contains unsupported characters")
+    return sanitized
 
 
 __all__ = ["safe_source_id"]

--- a/src/app/connectorNames.ts
+++ b/src/app/connectorNames.ts
@@ -1,0 +1,38 @@
+const CONNECTION_IDENTITY_KEYS = [
+    'host',
+    'server',
+    'server_hostname',
+    'endpoint',
+    'url',
+    'account_name',
+    'bucket',
+    'project_id',
+    'kusto_cluster',
+    'database',
+    'root_dir',
+] as const;
+
+const conciseIdentity = (value: string): string => {
+    const trimmed = value.trim().replace(/\/$/, '');
+    if (!trimmed) return '';
+
+    try {
+        const parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
+        return parsed.host || trimmed;
+    } catch {
+        return trimmed;
+    }
+};
+
+export const deriveConnectorDisplayName = (
+    loaderName: string,
+    params: Record<string, unknown>,
+): string => {
+    for (const key of CONNECTION_IDENTITY_KEYS) {
+        const value = params[key];
+        if (typeof value !== 'string') continue;
+        const identity = conciseIdentity(value);
+        if (identity) return `${loaderName} · ${identity}`;
+    }
+    return loaderName;
+};

--- a/src/app/utils.tsx
+++ b/src/app/utils.tsx
@@ -124,6 +124,7 @@ export const CONNECTOR_URLS = {
     DATA_LOADERS: '/api/data-loaders',
     LIST: '/api/connectors',
     CREATE: '/api/connectors',
+    UPDATE: (id: string) => `/api/connectors/${id}`,
     DELETE: (id: string) => `/api/connectors/${id}`,
 } as const;
 

--- a/src/components/ComponentType.tsx
+++ b/src/components/ComponentType.tsx
@@ -585,6 +585,7 @@ export interface ConnectorAuthPath {
 export interface ConnectorInstance {
     id: string;
     source_type: string;
+    type_name?: string;
     display_name: string;
     icon: string;
     connected: boolean;

--- a/src/components/ConnectorFormCard.tsx
+++ b/src/components/ConnectorFormCard.tsx
@@ -22,6 +22,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { apiRequest } from '../app/apiClient';
+import { deriveConnectorDisplayName } from '../app/connectorNames';
 import { CONNECTOR_URLS } from '../app/utils';
 import { dfActions } from '../app/dfSlice';
 import { AppDispatch } from '../app/store';
@@ -59,12 +60,12 @@ export const ConnectorFormCard: React.FC<ConnectorFormCardProps> = ({ messageId,
     const [metaError, setMetaError] = useState<string>('');
     const [loadingMeta, setLoadingMeta] = useState(true);
     const [expanded, setExpanded] = useState(defaultExpanded);
-    const [connectionName, setConnectionName] = useState<string>(prompt.connectionName || '');
     // Connected-state: collapsible details panel (non-sensitive only).
     const [connExpanded, setConnExpanded] = useState(false);
     const [connDetails, setConnDetails] = useState<Array<{ label: string; value: string }>>([]);
 
     const createdIdRef = useRef<string | null>(prompt.connectorId ?? null);
+    const generatedNameRef = useRef(prompt.connectionName || '');
     const seededRef = useRef(false);
 
     // Fetch the connector's param/auth schema. The agent only sends the type;
@@ -85,9 +86,6 @@ export const ConnectorFormCard: React.FC<ConnectorFormCardProps> = ({ messageId,
                     }));
                 }
                 setMeta(found);
-                if (found && !connectionName) {
-                    setConnectionName(found.name);
-                }
             })
             .catch(() => {
                 if (!cancelled) {
@@ -171,24 +169,26 @@ export const ConnectorFormCard: React.FC<ConnectorFormCardProps> = ({ messageId,
     // create-on-connect: called by DataLoaderForm right before it connects.
     const handleBeforeConnect = useCallback(async (params: Record<string, any>): Promise<string> => {
         if (createdIdRef.current) return createdIdRef.current;
+        const displayName = deriveConnectorDisplayName(meta?.name || sourceType, params);
         const { data } = await apiRequest<any>(CONNECTOR_URLS.CREATE, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 loader_type: sourceType,
-                display_name: connectionName.trim() || meta?.name || sourceType,
+                display_name: displayName,
                 icon: sourceType,
                 params,
                 persist: true,
             }),
         });
         createdIdRef.current = data.id;
+        generatedNameRef.current = displayName;
         return data.id;
-    }, [sourceType, connectionName, meta]);
+    }, [sourceType, meta]);
 
     const handleConnected = useCallback(async () => {
         const cid = createdIdRef.current;
-        let resolvedName = connectionName.trim() || meta?.name || sourceType;
+        let resolvedName = generatedNameRef.current || meta?.name || sourceType;
         if (cid) {
             try {
                 const { data } = await apiRequest<any>(CONNECTOR_URLS.LIST, { method: 'GET' });
@@ -234,7 +234,7 @@ export const ConnectorFormCard: React.FC<ConnectorFormCardProps> = ({ messageId,
             attachments: [],
             hidden: true,
         }));
-    }, [messageId, connectionName, meta, sourceType, dispatch, t]);
+    }, [messageId, meta, sourceType, dispatch, t]);
 
     const cardSx = {
         mt: 1,
@@ -349,12 +349,6 @@ export const ConnectorFormCard: React.FC<ConnectorFormCardProps> = ({ messageId,
                             authPaths={meta.auth_paths}
                             compact
                             hideInstructions
-                            connectionName={{
-                                label: t('upload.connectionNameLabel', { defaultValue: 'connection name' }),
-                                value: connectionName,
-                                placeholder: meta.name,
-                                onChange: setConnectionName,
-                            }}
                             onImport={() => {}}
                             onFinish={(status, message) => {
                                 dispatch(dfActions.addMessages({

--- a/src/views/DBTableManager.tsx
+++ b/src/views/DBTableManager.tsx
@@ -91,18 +91,10 @@ export const DataLoaderForm: React.FC<{
     delegatedLogin?: { login_url: string; label?: string; params?: string[] } | null,
     authMode?: string,
     authPaths?: ConnectorAuthPath[],
-    connectionName?: {
-        label: string,
-        value: string,
-        placeholder: string,
-        onChange: (value: string) => void,
-    },
     formTitle?: React.ReactNode,
     onImport: () => void,
     onFinish: (status: "success" | "error" | "warning", message: string, importedTables?: string[]) => void,
     onConnected?: () => void,
-    /** Called when the user clicks Delete. Receives the connectorId. */
-    onDelete?: (connectorId: string) => void,
     /** Called before the connect step. Returns the effective connectorId to use.
      *  Used by AddConnectionPanel to create the connector before connecting. */
     onBeforeConnect?: (params: Record<string, any>) => Promise<string>,
@@ -119,7 +111,7 @@ export const DataLoaderForm: React.FC<{
      *  the agent in chat. Populates the transient sensitive state so the user
      *  needn't retype; never persisted (see the redux-persist transform). */
     initialSensitiveParams?: Record<string, string>,
-}> = ({dataLoaderType, loaderType, paramDefs, authInstructions, connectorId, autoConnect, ssoAutoConnect, delegatedLogin, authMode, authPaths = [], connectionName, formTitle, onImport, onFinish, onConnected, onDelete, onBeforeConnect, hasStoredCredentials, compact = false, hideInstructions = false, initialSensitiveParams}) => {
+}> = ({dataLoaderType, loaderType, paramDefs, authInstructions, connectorId, autoConnect, ssoAutoConnect, delegatedLogin, authMode, authPaths = [], formTitle, onImport, onFinish, onConnected, onBeforeConnect, hasStoredCredentials, compact = false, hideInstructions = false, initialSensitiveParams}) => {
     const { t } = useTranslation();
     const dispatch = useDispatch<AppDispatch>();
     const loaderTypeKey = loaderType || dataLoaderType;
@@ -560,17 +552,18 @@ export const DataLoaderForm: React.FC<{
             {/* Connection form. Catalog browsing + table loading live in
                 the data-source sidebar — this dialog is for create / edit /
                 re-auth only. */}
-            <>
+            <Box sx={{
+                width: '100%',
+                maxWidth: compact ? '100%' : 960,
+                mx: 'auto',
+                px: compact ? 0 : { xs: 0, sm: 1.5 },
+                boxSizing: 'border-box',
+            }}>
                 {formTitle && (
-                    <Typography sx={{ fontSize: 13, lineHeight: 1.4, fontWeight: 600, color: 'text.primary', mb: 1 }}>
+                    <Typography sx={{ fontSize: 13, lineHeight: 1.4, fontWeight: 400, color: 'secondary.main', mb: 2 }}>
                         {formTitle}
                     </Typography>
                 )}
-                {!onBeforeConnect && (
-                    <Typography variant="body2" sx={{fontSize: 11.5, color: 'secondary.main', fontWeight: 600, mt: 1}}>
-                        {dataLoaderType}
-                    </Typography>
-                    )}
                     {(() => {
                         const hasTiers = paramDefs.some(p => p.tier);
                         const renderTimelineStep = (
@@ -639,6 +632,20 @@ export const DataLoaderForm: React.FC<{
                             ...formTextSx,
                             color: 'text.secondary',
                         };
+                        const fieldRowSx = {
+                            display: 'grid',
+                            gridTemplateColumns: 'minmax(0, 1fr)',
+                            rowGap: 0.25,
+                            alignItems: 'stretch',
+                            width: '100%',
+                            maxWidth: 420,
+                            minWidth: 0,
+                        };
+                        const fieldLabelSx = {
+                            ...secondaryTextSx,
+                            textAlign: 'left',
+                            overflowWrap: 'anywhere',
+                        };
                         // Typical Data Formulator body size (12px). Fields, labels
                         // and placeholders all sit on this one scale.
                         const inputSx = {
@@ -690,27 +697,31 @@ export const DataLoaderForm: React.FC<{
                                 loaderTypeKey === 'kusto' && name === 'kusto_cluster';
                             const isKustoDatabase = (name: string) =>
                                 loaderTypeKey === 'kusto' && name === 'kusto_database';
-                            // Left label, right input box. The per-field hint lives
-                            // inside the box as its placeholder, so each row stays a
-                            // single clean line: "name        [ value / hint ]".
+                            // Keep labels above inputs so long localized descriptions
+                            // cannot compete with or overlap the editable field.
                             const renderFieldRow = (paramDef: typeof tierParams[number], input: React.ReactNode) => (
                                 <Box
                                     key={paramDef.name}
-                                    sx={{
-                                        display: 'grid',
-                                        gridTemplateColumns: compact ? '104px minmax(0, 1fr)' : '124px minmax(0, 340px)',
-                                        columnGap: 2,
-                                        alignItems: 'center',
-                                    }}
+                                    sx={fieldRowSx}
                                 >
-                                    <Typography sx={{ ...secondaryTextSx, textAlign: 'left' }}>
+                                    <Typography sx={fieldLabelSx}>
                                         {paramDef.name}{paramDef.required ? ' *' : ''}
                                     </Typography>
                                     <Box sx={{ minWidth: 0 }}>{input}</Box>
                                 </Box>
                             );
                             return (
-                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: compact ? 1.5 : 2, maxWidth: 640 }}>
+                            <Box sx={{
+                                display: 'grid',
+                                gridTemplateColumns: 'minmax(0, 1fr)',
+                                columnGap: 4,
+                                rowGap: compact ? 1.5 : 2,
+                                width: '100%',
+                                maxWidth: 860,
+                                '@container (min-width: 720px)': {
+                                    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                                },
+                            }}>
                                 {tierParams.map((paramDef) => (
                                     isKustoCluster(paramDef.name) ? (
                                         renderFieldRow(paramDef,
@@ -891,42 +902,21 @@ export const DataLoaderForm: React.FC<{
                             ? t('db.createConnector', { defaultValue: 'Create Connector' })
                             : t('db.connect', { suffix: (params.table_filter || '').trim() ? t('db.withFilter') : '' });
                         let stepNumber = 0;
-                        const connectionStep = connectionName || connectionParams.length > 0 ? ++stepNumber : 0;
+                        const connectionStep = connectionParams.length > 0 ? ++stepNumber : 0;
                         const scopeStep = filterParams.length > 0 ? ++stepNumber : 0;
                         const authStep = ++stepNumber;
+                        const showConnectAction = !hasDelegated || selectedAuthParams.length > 0;
+                        const actionStep = showConnectAction ? ++stepNumber : 0;
 
                         return (
-                            <Box sx={{ mt: 1.5, maxWidth: 1120 }}>
+                            <Box sx={{ mt: 1.5, width: '100%', containerType: 'inline-size' }}>
                                 {/* Connection identity and source coordinates belong together. */}
-                                {(connectionName || connectionParams.length > 0) && (
+                                {connectionParams.length > 0 && (
                                     renderTimelineStep(
                                         connectionStep,
                                         t('db.tierConnection'),
                                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: compact ? 1.5 : 2 }}>
-                                            {connectionName && (
-                                                <Box sx={{
-                                                    display: 'grid',
-                                                    gridTemplateColumns: compact ? '104px minmax(0, 1fr)' : '124px minmax(0, 340px)',
-                                                    columnGap: 2,
-                                                    alignItems: 'center',
-                                                }}>
-                                                    <Typography sx={{ ...secondaryTextSx, textAlign: 'left' }}>
-                                                        {connectionName.label}
-                                                    </Typography>
-                                                    <Box sx={{ minWidth: 0 }}>
-                                                        <DraftTextField
-                                                            key={`connection-name-${dataLoaderType}`}
-                                                            sx={inputSx}
-                                                            variant="standard" size="small" fullWidth
-                                                            value={connectionName.value}
-                                                            placeholder={connectionName.placeholder}
-                                                            onDraftChange={connectionName.onChange}
-                                                            onCommit={connectionName.onChange}
-                                                        />
-                                                    </Box>
-                                                </Box>
-                                            )}
-                                            {connectionParams.length > 0 && renderParamGrid(connectionParams)}
+                                            {renderParamGrid(connectionParams)}
                                             {advancedConnectionParams.length > 0 && (
                                                 <Box>
                                                     <Button
@@ -1108,7 +1098,22 @@ export const DataLoaderForm: React.FC<{
                                         renderParamGrid(selectedAuthParams)
                                     )}
 
-                                    {(!hasDelegated || selectedAuthParams.length > 0) && (
+                                    </>,
+                                    !showConnectAction,
+                                )}
+
+                                {showConnectAction && renderTimelineStep(
+                                    actionStep,
+                                    null,
+                                    <Box sx={{
+                                        display: 'flex',
+                                        flexWrap: 'wrap',
+                                        alignItems: 'center',
+                                        justifyContent: 'space-between',
+                                        gap: 1.5,
+                                        width: '100%',
+                                        maxWidth: 860,
+                                    }}>
                                         <Button
                                             variant="contained" color="primary" size="small"
                                             disabled={isConnecting}
@@ -1117,35 +1122,30 @@ export const DataLoaderForm: React.FC<{
                                                 minWidth: 80,
                                                 height: 30,
                                                 fontSize: 12,
-                                                mt: selectedAuthParams.length > 0 ? 1.25 : 1,
                                             }}
                                             onClick={() => connectAndListTables()}>
                                             {connectLabel}
                                         </Button>
-                                    )}
-                                    </>,
+                                        {paramDefs.length > 0 && (
+                                            <FormControlLabel
+                                                sx={{ m: 0, ml: 'auto', flexShrink: 0 }}
+                                                control={(
+                                                    <Checkbox
+                                                        size="small"
+                                                        checked={persistCredentials}
+                                                        onChange={(event) => setPersistCredentials(event.target.checked)}
+                                                        sx={{ p: 0.25, mr: 0.25 }}
+                                                    />
+                                                )}
+                                                label={(
+                                                    <Typography sx={{ ...secondaryTextSx, fontSize: 11 }}>
+                                                        {t('db.rememberCredentials')}
+                                                    </Typography>
+                                                )}
+                                            />
+                                        )}
+                                    </Box>,
                                     true,
-                                )}
-
-                                {paramDefs.length > 0 && (
-                                    <Box sx={{ ml: 4.75, mt: 1 }}>
-                                        <FormControlLabel
-                                            sx={{ m: 0 }}
-                                            control={(
-                                                <Checkbox
-                                                    size="small"
-                                                    checked={persistCredentials}
-                                                    onChange={(event) => setPersistCredentials(event.target.checked)}
-                                                    sx={{ p: 0 }}
-                                                />
-                                            )}
-                                            label={(
-                                                <Typography sx={secondaryTextSx}>
-                                                    {t('db.rememberCredentials')}
-                                                </Typography>
-                                            )}
-                                        />
-                                    </Box>
                                 )}
                             </Box>
                         );
@@ -1155,7 +1155,7 @@ export const DataLoaderForm: React.FC<{
                             sx={{
                                 mt: 2,
                                 ml: 4.75,
-                                maxWidth: 760,
+                                maxWidth: 860,
                                 borderRadius: 1,
                                 bgcolor: 'action.hover',
                                 color: 'text.secondary',
@@ -1206,18 +1206,7 @@ export const DataLoaderForm: React.FC<{
                             )}
                         </Box>
                     )}
-                    {onDelete && connectorIdRef.current && (
-                        <Box sx={{ mt: 2 }}>
-                            <Button
-                                variant="outlined" size="small" color="error"
-                                sx={{ textTransform: "none", fontSize: 11, height: 26, minWidth: 0 }}
-                                onClick={() => onDelete(connectorIdRef.current!)}
-                            >
-                                {t('db.deleteConnector', { defaultValue: 'Delete' })}
-                            </Button>
-                        </Box>
-                    )}
-                </>
+                </Box>
         </Box>
     );
 }

--- a/src/views/UnifiedDataUploadDialog.tsx
+++ b/src/views/UnifiedDataUploadDialog.tsx
@@ -29,6 +29,7 @@ import { StreamIcon, getConnectorIcon, connectorSortOrder } from '../icons';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import HistoryIcon from '@mui/icons-material/History';
 import BoltOutlinedIcon from '@mui/icons-material/BoltOutlined';
 import Paper from '@mui/material/Paper';
@@ -46,6 +47,7 @@ import { AgentChatInput } from './AgentChatInput';
 import { buildDataLoadingSuggestions, buildDataLoadingQuickActions } from './dataLoadingSuggestions';
 import { getUrls, CONNECTOR_URLS } from '../app/utils';
 import { apiRequest } from '../app/apiClient';
+import { deriveConnectorDisplayName } from '../app/connectorNames';
 import { generateUUID } from '../app/identity';
 import { DataLoaderForm } from './DBTableManager';
 import { MultiTablePreview } from './MultiTablePreview';
@@ -1020,7 +1022,6 @@ const AddConnectionPanel: React.FC<{
     const [disabledLoaders, setDisabledLoaders] = useState<Record<string, {install_hint: string}>>({});
     const [pluginsInfo, setPluginsInfo] = useState<PluginsInfo | null>(null);
     const [selectedType, setSelectedType] = useState<string>('');
-    const displayNameRef = useRef('');
     const dispatch = useDispatch<AppDispatch>();
     const identityKey = useSelector((state: DataFormulatorState) => `${state.identity.type}:${state.identity.id}`);
     // Track the created connector ID so DataLoaderForm can use it
@@ -1047,7 +1048,6 @@ const AddConnectionPanel: React.FC<{
                         : undefined;
                     const chosen = preferred || data.loaders[0];
                     setSelectedType(chosen.type);
-                    displayNameRef.current = chosen.name;
                 }
             })
             .catch(() => { /* loader types unavailable — form will be empty */ });
@@ -1057,7 +1057,6 @@ const AddConnectionPanel: React.FC<{
 
     const handleSelectLoader = (loader: LoaderType) => {
         setSelectedType(loader.type);
-        displayNameRef.current = loader.name;
         createdIdRef.current = null;
     };
 
@@ -1071,7 +1070,7 @@ const AddConnectionPanel: React.FC<{
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 loader_type: selectedType,
-                display_name: displayNameRef.current.trim() || selectedLoader?.name || selectedType,
+                display_name: deriveConnectorDisplayName(selectedLoader?.name || selectedType, params),
                 icon: selectedType,
                 params,
                 persist: true,
@@ -1104,14 +1103,16 @@ const AddConnectionPanel: React.FC<{
     const sidebarButtonSx = (typeKey: string) => ({
         fontSize: 12,
         textTransform: 'none' as const,
-        width: '100%',
+        width: { xs: 'auto', sm: '100%' },
+        minWidth: 'max-content',
         justifyContent: 'flex-start',
         textAlign: 'left' as const,
         borderRadius: 0,
         py: 1,
         px: 2,
         color: selectedType === typeKey ? 'primary.main' : 'text.secondary',
-        borderRight: selectedType === typeKey ? 2 : 0,
+        borderRight: { xs: 0, sm: selectedType === typeKey ? 2 : 0 },
+        borderBottom: { xs: selectedType === typeKey ? 2 : 0, sm: 0 },
         borderColor: 'primary.main',
     });
 
@@ -1123,18 +1124,21 @@ const AddConnectionPanel: React.FC<{
     }
 
     return (
-        <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+        <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, height: '100%', overflow: 'hidden' }}>
             {/* Left sidebar: loader types */}
             <Box sx={{
-                display: 'flex', flexDirection: 'column',
-                width: 180, minWidth: 180, maxWidth: 180,
-                borderRight: `1px solid ${borderColor.divider}`,
-                overflowY: 'auto', overflowX: 'hidden',
-                pt: 1,
+                display: 'flex', flexDirection: { xs: 'row', sm: 'column' },
+                width: { xs: '100%', sm: 180 }, minWidth: { xs: 0, sm: 180 }, maxWidth: { xs: 'none', sm: 180 },
+                borderRight: { xs: 0, sm: `1px solid ${borderColor.divider}` },
+                borderBottom: { xs: `1px solid ${borderColor.divider}`, sm: 0 },
+                overflowY: { xs: 'hidden', sm: 'auto' }, overflowX: { xs: 'auto', sm: 'hidden' },
+                pt: { xs: 0, sm: 1 },
+                flexShrink: 0,
             }}>
                 <Typography variant="caption" sx={{
                     px: 2, pb: 0.5, color: 'text.disabled',
                     fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5,
+                    display: { xs: 'none', sm: 'block' },
                 }}>
                     {t('upload.dataSourceTypes', { defaultValue: 'Data Sources' })}
                 </Typography>
@@ -1185,7 +1189,8 @@ const AddConnectionPanel: React.FC<{
                             <Button
                                 variant="text" size="small" disabled
                                 sx={{
-                                    fontSize: 12, textTransform: 'none', width: '100%',
+                                    fontSize: 12, textTransform: 'none', width: { xs: 'auto', sm: '100%' },
+                                    minWidth: 'max-content',
                                     justifyContent: 'flex-start', textAlign: 'left',
                                     borderRadius: 0, py: 1, px: 2,
                                     color: 'text.disabled !important',
@@ -1240,12 +1245,6 @@ const AddConnectionPanel: React.FC<{
                                     name: selectedLoader.name,
                                     defaultValue: 'Create a connection to {{name}}',
                                 })}
-                                connectionName={{
-                                    label: t('upload.connectionNameLabel', { defaultValue: 'connection name' }),
-                                    value: displayNameRef.current || selectedLoader.name,
-                                    placeholder: selectedLoader.name,
-                                    onChange: (value) => { displayNameRef.current = value; },
-                                }}
                                 onImport={() => {}}
                                 onFinish={(status, message) => {
                                     dispatch(dfActions.addMessages({
@@ -1308,6 +1307,8 @@ export const UnifiedDataUploadDialog: React.FC<UnifiedDataUploadDialogProps> = (
 
     // Connector instances fetched from GET /api/connectors
     const [connectorInstances, setConnectorInstances] = useState<ConnectorInstance[]>([]);
+    const [connectorPendingDelete, setConnectorPendingDelete] = useState<ConnectorInstance | null>(null);
+    const [connectorNameDraft, setConnectorNameDraft] = useState('');
 
     // Fetch connector list when dialog opens
     const refreshConnectors = useCallback(() => {
@@ -1875,6 +1876,63 @@ export const UnifiedDataUploadDialog: React.FC<UnifiedDataUploadDialogProps> = (
         return tabTitles[activeTab] || t('upload.addData');
     };
 
+    const activeConnector = activeTab.startsWith('connector:')
+        ? connectorInstances.find(c => c.id === activeTab.slice('connector:'.length))
+        : undefined;
+
+    useEffect(() => {
+        setConnectorNameDraft(activeConnector?.display_name || '');
+    }, [activeConnector?.id, activeConnector?.display_name]);
+
+    const commitConnectorName = async () => {
+        if (!activeConnector) return;
+        const displayName = connectorNameDraft.trim();
+        if (!displayName) {
+            setConnectorNameDraft(activeConnector.display_name);
+            return;
+        }
+        if (displayName === activeConnector.display_name) return;
+
+        try {
+            await apiRequest(CONNECTOR_URLS.UPDATE(activeConnector.id), {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ display_name: displayName }),
+            });
+            setConnectorInstances(prev => prev.map(connector => (
+                connector.id === activeConnector.id
+                    ? { ...connector, display_name: displayName }
+                    : connector
+            )));
+            onConnectorsChanged?.();
+        } catch (err: any) {
+            setConnectorNameDraft(activeConnector.display_name);
+            dispatch(dfActions.addMessages({
+                timestamp: Date.now(), component: 'connector', type: 'error',
+                value: err.message || t('upload.errors.failedToRenameConnector', { defaultValue: 'Failed to rename connector' }),
+            }));
+        }
+    };
+
+    const deleteConnector = async (connector: ConnectorInstance) => {
+        try {
+            await apiRequest(CONNECTOR_URLS.DELETE(connector.id), { method: 'DELETE' });
+            setConnectorInstances(prev => prev.filter(c => c.id !== connector.id));
+            setConnectorPendingDelete(null);
+            setActiveTab('menu');
+            onConnectorsChanged?.();
+            dispatch(dfActions.addMessages({
+                timestamp: Date.now(), component: 'connector', type: 'success',
+                value: t('upload.messages.deletedConnector', { name: connector.display_name, defaultValue: 'Deleted connector "{{name}}"' }),
+            }));
+        } catch (err: any) {
+            dispatch(dfActions.addMessages({
+                timestamp: Date.now(), component: 'connector', type: 'error',
+                value: err.message || t('upload.errors.failedToDeleteConnector', { defaultValue: 'Failed to delete connector' }),
+            }));
+        }
+    };
+
     return (
         <Dialog
             open={open}
@@ -1902,9 +1960,55 @@ export const UnifiedDataUploadDialog: React.FC<UnifiedDataUploadDialogProps> = (
                         <ArrowBackIcon fontSize="small" />
                     </IconButton>
                 )}
-                <Typography variant="h6" component="span">
-                    {activeTab === 'menu' ? t('upload.title') : getCurrentTabTitle()}
-                </Typography>
+                {activeConnector ? (
+                    <Box sx={{ minWidth: 0, display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                        <TextField
+                            value={connectorNameDraft}
+                            onChange={(event) => setConnectorNameDraft(event.target.value)}
+                            onBlur={() => void commitConnectorName()}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter') event.currentTarget.querySelector('input')?.blur();
+                                if (event.key === 'Escape') {
+                                    setConnectorNameDraft(activeConnector.display_name);
+                                    event.currentTarget.querySelector('input')?.blur();
+                                }
+                            }}
+                            variant="standard"
+                            inputProps={{ 'aria-label': t('upload.connectionName', { defaultValue: 'Connector name' }) }}
+                            sx={{
+                                width: `clamp(120px, ${Math.max(connectorNameDraft.length + 1, 8)}ch, 360px)`,
+                                '& .MuiInputBase-input': {
+                                    py: 0,
+                                    fontSize: 20,
+                                    lineHeight: 1.35,
+                                    fontWeight: 500,
+                                    letterSpacing: 0,
+                                },
+                                '& .MuiInput-underline:before': { borderBottomColor: 'transparent' },
+                                '& .MuiInput-underline:hover:not(.Mui-disabled):before': { borderBottomColor: 'divider' },
+                            }}
+                        />
+                        <Typography sx={{ flexShrink: 0, fontSize: 13, color: 'secondary.main', fontWeight: 600 }}>
+                            ({activeConnector.icon.replaceAll('_', ' ').toUpperCase()})
+                        </Typography>
+                    </Box>
+                ) : (
+                    <Typography variant="h6" component="span">
+                        {activeTab === 'menu' ? t('upload.title') : getCurrentTabTitle()}
+                    </Typography>
+                )}
+                {activeConnector?.deletable && (
+                    <Tooltip title={t('sidebar.deleteConnector', { defaultValue: 'Delete connector' })}>
+                        <IconButton
+                            size="small"
+                            color="error"
+                            aria-label={t('sidebar.deleteConnector', { defaultValue: 'Delete connector' })}
+                            onClick={() => setConnectorPendingDelete(activeConnector)}
+                        >
+                            <DeleteOutlineIcon sx={{ fontSize: 18 }} />
+                        </IconButton>
+                    </Tooltip>
+                )}
                 {activeTab === 'extract' && dataLoadingChatMessages.length > 0 && (
                     <Tooltip title={t('upload.resetExtraction')}>
                         <IconButton 
@@ -2484,23 +2588,6 @@ export const UnifiedDataUploadDialog: React.FC<UnifiedDataUploadDialogProps> = (
                                     handleClose();
                                     dispatch(dfActions.focusConnector(conn.id));
                                 }}
-                                onDelete={conn.deletable ? async (cid) => {
-                                    try {
-                                        await apiRequest(CONNECTOR_URLS.DELETE(cid), { method: 'DELETE' });
-                                        setConnectorInstances(prev => prev.filter(c => c.id !== cid));
-                                        setActiveTab('menu');
-                                        onConnectorsChanged?.();
-                                        dispatch(dfActions.addMessages({
-                                            timestamp: Date.now(), component: 'connector', type: 'success',
-                                            value: t('upload.messages.deletedConnector', { name: conn.display_name, defaultValue: 'Deleted connector "{{name}}"' }),
-                                        }));
-                                    } catch (err: any) {
-                                        dispatch(dfActions.addMessages({
-                                            timestamp: Date.now(), component: 'connector', type: 'error',
-                                            value: err.message || t('upload.errors.failedToDeleteConnector', { defaultValue: 'Failed to delete connector' }),
-                                        }));
-                                    }
-                                } : undefined}
                             />
                         </Box>
                     </TabPanel>
@@ -2538,6 +2625,31 @@ export const UnifiedDataUploadDialog: React.FC<UnifiedDataUploadDialogProps> = (
                     with the local_folder loader pre-selected. */}
 
             </DialogContent>
+            <Dialog open={connectorPendingDelete !== null} onClose={() => setConnectorPendingDelete(null)} maxWidth="xs" fullWidth>
+                <DialogTitle>
+                    {t('sidebar.deleteConnectorTitle', { defaultValue: 'Delete connector' })}
+                </DialogTitle>
+                <DialogContent>
+                    <Typography sx={{ fontSize: 13 }}>
+                        {t('sidebar.deleteConnectorConfirm', {
+                            name: connectorPendingDelete?.display_name || '',
+                            defaultValue: 'Are you sure you want to delete "{{name}}"? Imported data will not be affected.',
+                        })}
+                    </Typography>
+                </DialogContent>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, px: 3, pb: 2 }}>
+                    <Button onClick={() => setConnectorPendingDelete(null)}>
+                        {t('cancel', { defaultValue: 'Cancel' })}
+                    </Button>
+                    <Button
+                        color="error"
+                        variant="contained"
+                        onClick={() => connectorPendingDelete && void deleteConnector(connectorPendingDelete)}
+                    >
+                        {t('sidebar.deleteConfirmBtn', { defaultValue: 'Delete' })}
+                    </Button>
+                </Box>
+            </Dialog>
         </Dialog>
     );
 };

--- a/tests/backend/data/test_data_connector_framework.py
+++ b/tests/backend/data/test_data_connector_framework.py
@@ -451,6 +451,23 @@ class TestAuthRoutes:
         assert resp.status_code == 200
         assert resp.get_json()["status"] == "success"
 
+    def test_rename_connector_preserves_stable_id(self, connected_client, source):
+        with patch.object(DataConnector, "_get_identity", return_value="test-user"), \
+             patch("data_formulator.data_connector._update_user_connector_display_name") as persist:
+            resp = connected_client.patch(
+                "/api/connectors/mock_db",
+                json={"display_name": "Analytics warehouse"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["data"] == {
+            "id": "mock_db",
+            "display_name": "Analytics warehouse",
+        }
+        assert source._source_id == "mock_db"
+        assert source._display_name == "Analytics warehouse"
+        persist.assert_called_once_with("test-user", "mock_db", "Analytics warehouse")
+
     def test_disconnect_connector_clears_loader_and_credentials(self, connected_client, source):
         """Disconnect keeps the connector but clears active and stored credentials."""
         with patch.object(DataConnector, "_get_identity", return_value="test-user"), \


### PR DESCRIPTION
This pull request introduces several improvements to the connector management experience, focusing on making advanced connection parameters less prominent, automating display name generation for connectors, and adding an API endpoint for renaming user connectors. The UI no longer prompts users for a connection name during creation; instead, a display name is auto-generated from key parameters, and users can rename connectors later if desired. Additionally, backend and API changes support these new behaviors.

**Connector display name automation and API enhancements:**

- **Auto-generation of connector display names:** The UI now derives a connector's display name automatically based on key connection parameters (e.g., host, database, project_id) using the new `deriveConnectorDisplayName` function in `connectorNames.ts`. Users are no longer prompted for a connection name during creation. [[1]](diffhunk://#diff-dca40080ce83c678c77b23b43d324e7e9bd2cf9d4a64aeef2e1e37369ce618e8R1-R38) [[2]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cR25) [[3]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cL62-R68) [[4]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cL88-L90) [[5]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cR172-R191) [[6]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cL237-R237) [[7]](diffhunk://#diff-c8cdfe6b801dc1b21bfe8598db461c7568b44462977c9ec5258f78831e7e333cL352-L357) [[8]](diffhunk://#diff-1395e0ae88006838ef6f599e2fde5537180bb1454290305b0da0b7a0fbee76fbL94-L105) [[9]](diffhunk://#diff-1395e0ae88006838ef6f599e2fde5537180bb1454290305b0da0b7a0fbee76fbL122-R114)

- **Backend support for renaming connectors:** A new PATCH API endpoint (`/api/connectors/<connector_id>`) allows users to rename their connectors after creation, with validation and admin protections. [[1]](diffhunk://#diff-891688655c7828f3fb155c97f0079b687f82f16ece674809c238b46ec3abd00bR1448-R1479) [[2]](diffhunk://#diff-00b4c71f3a72e417622504e3f645bc8f7755d27e59e902cc00d44633f431a9beR127)

**Parameter UI improvements:**

- **Advanced parameter labeling:** Several connection parameters across various data loaders (e.g., `port`, `endpoint`, `workgroup`, `output_location`, `location`, `query_timeout`) are now marked as `"advanced": true` in their parameter definitions. This allows the UI to hide these fields by default, reducing clutter for most users. [[1]](diffhunk://#diff-0e5442a0e10fcd13f8385c9bdefa37be04c330523fda9ff5c23a01151cf6f404L71-R74) [[2]](diffhunk://#diff-d871a4b990034448da2ea7617b43ef7ba5eeb4cd90051f65dbac1ce4a3ca2cf9L31-R31) [[3]](diffhunk://#diff-013ee07164c5a61850659cde155a3ca56ca86a80c2283e86804965a380e715e6L26-R26) [[4]](diffhunk://#diff-072c0f7785be63c8d430e77d3997b38a22b71ba05bbb78d5ab1f15b16772c643L26-R26) [[5]](diffhunk://#diff-25f50903d293cd4762683ee67a55fe33c3957d9210a44d54857819f228962a10R61) [[6]](diffhunk://#diff-efdb07c4c6cd70563af52149ff1a9625641f43d3824dad5ecdc63b0408bc92f6L34-R34) [[7]](diffhunk://#diff-31b0577603847fcf3d4c0edba0b46c557e356b77226a8136e31835f8ef1a21e4L38-R38) [[8]](diffhunk://#diff-303028ba030b9825f0d8f8846f958c3c704f259181fd2a0eb7e546e44c9c00bbR57) [[9]](diffhunk://#diff-303028ba030b9825f0d8f8846f958c3c704f259181fd2a0eb7e546e44c9c00bbR66)

**API and type updates:**

- **Connector type and display name fields:** The backend now returns both `type_name` and `display_name` for connectors, and the frontend `ConnectorInstance` type reflects this. [[1]](diffhunk://#diff-891688655c7828f3fb155c97f0079b687f82f16ece674809c238b46ec3abd00bR1244) [[2]](diffhunk://#diff-a51cb8851e52923c9847a5633aadf4f5e8624922d39d817800e52d76eb973e3eR588)

These changes streamline the connector creation workflow, reduce user friction, and improve the clarity and management of connector display names.